### PR TITLE
Protect repo with CODEOWNERS file

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,3 @@
+# By default, these are the owners of all code in the repo
+# This means their approval is required for PRs before PRs can be merged
+* @wenxin-c @nichyjt @haoyangw


### PR DESCRIPTION
All team members can review and merge PRs.

This is less organised.

Require specific users(maintainers and owner) to approve PRs before they can be merged to ensure accountability when managing the team repo.