### PR TITLE
Add Command Parser feature

### DIFF
--- a/src/main/java/seedu/duke/command/BadCommandException.java
+++ b/src/main/java/seedu/duke/command/BadCommandException.java
@@ -1,6 +1,6 @@
 package seedu.duke.command;
 
-public class BadCommandException extends Exception{
+public class BadCommandException extends Exception {
     public BadCommandException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/seedu/duke/command/BadCommandException.java
+++ b/src/main/java/seedu/duke/command/BadCommandException.java
@@ -1,0 +1,7 @@
+package seedu.duke.command;
+
+public class BadCommandException extends Exception{
+    public BadCommandException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/seedu/duke/command/CommandParser.java
+++ b/src/main/java/seedu/duke/command/CommandParser.java
@@ -97,6 +97,13 @@ public class CommandParser {
         return payload;
     }
 
+    /**
+     * Takes in raw user input and splits it into Argument-Payload pairs
+     *
+     * @param userInput Raw user input from stdin in string form
+     * @return HashMap mapping a Argument (key) to a Payload (value)
+     * @throws BadCommandException when command is empty or is problematic
+     */
     public HashMap<String, String> parseUserInput(String userInput) throws BadCommandException {
         if (userInput.length() == 0) {
             throw new BadCommandException(ERROR_EMPTY_COMMAND);
@@ -111,7 +118,17 @@ public class CommandParser {
         return argumentPayload;
     }
 
-    // Returns the main argument (action)
+    /**
+     * Takes in a string and returns the inferred "Main Argument"
+     * <br>
+     * Practically, this is the <b>First</b> argument of any command string.
+     * For example, <code>"hb add --name foobar"</code> <br>
+     * Has main argument "hb"
+     *
+     * @param userInput Any string input representing a command
+     * @return the inferred Main Argument
+     * @throws BadCommandException when String is empty
+     */
     public String getMainArgument(String userInput) throws BadCommandException {
         userInput = userInput.strip();
         String[] parameters = userInput.split(" ");

--- a/src/main/java/seedu/duke/command/CommandParser.java
+++ b/src/main/java/seedu/duke/command/CommandParser.java
@@ -1,0 +1,84 @@
+package seedu.duke.command;
+
+import java.util.HashMap;
+
+/**
+ * A CommandParser processes user input from a defined format <p>
+ * <p><br>
+ * Each user input via console consists of: <br>
+ * 1. COMMANDS - A Argument and Payload pairs <br>
+ * 2. ARGUMENTS - String representing the action/parameters of the command <br>
+ * 3. PAYLOADS - value of the action/parameters <br>
+ * In short, user input is a list of commands, each command containing arguments and payloads. <br>
+ * <br>
+ * For example, a given user input: <code>"deadline work on CS2113 --by Sunday"</code>
+ * <li>Has commands ["deadline work on CS2113", "by Sunday"]</li>
+ * <li>Has arguments ["deadline", "by"]</li>
+ * <li>Has payloads ["work on CS2113", ["Sunday"]</li>
+ * <br>
+ * Further, we define the FIRST command to be the MAIN command of any given user input. <br>
+ * So, <code>"deadline work on CS2113 --by Sunday"</code> has <code>"deadline work on CS2113"</code>
+ * as the main command
+ */
+public class CommandParser {
+
+    private static final String ARGUMENT_DELIMITER = " --";
+    private static final String PAYLOAD_DELIMITER = " ";
+
+    // Message string constants for errors and ui
+    private static final String ERROR_EMPTY_COMMAND = "Command length is empty.";
+    private static final String ERROR_EMPTY_ARGUMENT = "Command is missing an argument!";
+
+    /**
+     * Constructs an instance of CommandParser. <br>
+     * <p>
+     * CommandParser should be used to break down raw user input into
+     * logical <code>[Argument,Payload]</code> pairs
+     */
+    public CommandParser() {
+
+    }
+
+    private String[] splitIntoCommands(String fullCommandString) {
+        // Perform a string length sanity check
+        assert fullCommandString.length() > 0;
+        return fullCommandString.split(ARGUMENT_DELIMITER);
+    }
+
+    private String getArgumentFromCommand(String commandString) throws BadCommandException {
+        String[] words = commandString.split(PAYLOAD_DELIMITER);
+        // Bad input checks
+        if (words.length == 0) {
+            throw new BadCommandException(ERROR_EMPTY_ARGUMENT);
+        }
+        return words[0];
+    }
+
+    private String getPayloadFromCommand(String commandString) {
+        String[] words = commandString.split(PAYLOAD_DELIMITER);
+        String payload = "";
+        for (int i = 0; i < words.length; ++i) {
+            payload = payload.concat(words[i]);
+            if (i != words.length - 1) {
+                payload = payload.concat(PAYLOAD_DELIMITER);
+            }
+        }
+        // No checks for payload length is done as payload CAN be empty
+        return payload;
+    }
+
+    public HashMap<String, String> parseUserInput(String userInput) throws BadCommandException {
+        if (userInput.length() == 0) {
+            throw new BadCommandException(ERROR_EMPTY_COMMAND);
+        }
+        HashMap<String, String> argumentPayload = new HashMap<>();
+        String[] commands = splitIntoCommands(userInput);
+        for (String command : commands) {
+            String argument = getArgumentFromCommand(command);
+            String payload = getPayloadFromCommand(command);
+            argumentPayload.put(argument, payload);
+        }
+        return argumentPayload;
+    }
+
+}

--- a/src/main/java/seedu/duke/command/CommandParser.java
+++ b/src/main/java/seedu/duke/command/CommandParser.java
@@ -59,7 +59,7 @@ public class CommandParser {
         //    So, check for "--" prefix
 
         String[] cleanCommands = new String[commands.length];
-        for (int i=0; i<commands.length; ++i) {
+        for (int i = 0; i < commands.length; ++i) {
             String currentCommand = commands[i];
             // Case 1 check
             if (currentCommand.startsWith(" ") || currentCommand.length() == 0) {

--- a/src/main/java/seedu/duke/command/CommandParser.java
+++ b/src/main/java/seedu/duke/command/CommandParser.java
@@ -32,7 +32,7 @@ public class CommandParser {
     private static final String PAYLOAD_DELIMITER = " ";
 
     // Message string constants for errors and ui
-    private static final String ERROR_EMPTY_COMMAND = "Command length is empty.";
+    private static final String ERROR_EMPTY_COMMAND = "Command is empty!";
     private static final String ERROR_EMPTY_ARGUMENT = "Command is missing an argument!";
 
     /**

--- a/src/main/java/seedu/duke/command/CommandParser.java
+++ b/src/main/java/seedu/duke/command/CommandParser.java
@@ -6,11 +6,19 @@ import java.util.HashMap;
  * A CommandParser processes user input from a defined format <p>
  * <p><br>
  * Each user input via console consists of: <br>
- * 1. COMMANDS - A Argument and Payload pairs <br>
- * 2. ARGUMENTS - String representing the action/parameters of the command <br>
- * 3. PAYLOADS - value of the action/parameters <br>
- * In short, user input is a list of commands, each command containing arguments and payloads. <br>
- * <br>
+ * <ol>
+ * <li>COMMANDS - A Argument and Payload pairs </li><br>
+ * <li>ARGUMENTS - String representing the action/parameters of the command </li><br>
+ * <li>PAYLOADS - value of the action/parameters </li><br>
+ * </ol>
+ * <p>
+ * In short, user input is a list of commands, each command containing arguments and payloads. <br><br>
+ * Further, we define the FIRST command to be the MAIN command of any given user input. <br>
+ * So, <code>"deadline work on CS2113 --by Sunday"</code> has <code>"deadline work on CS2113"</code>
+ * as the main command <br><br>
+ * Each command (argument-payload pair) except for the main command MUST
+ * be delimited by <code>" --"</code> (whitespace intentional)
+ * <br><br>
  * For example, a given user input: <code>"deadline work on CS2113 --by Sunday"</code>
  * <li>Has commands ["deadline work on CS2113", "by Sunday"]</li>
  * <li>Has arguments ["deadline", "by"]</li>

--- a/src/main/java/seedu/duke/command/CommandParser.java
+++ b/src/main/java/seedu/duke/command/CommandParser.java
@@ -16,9 +16,6 @@ import java.util.HashMap;
  * <li>Has arguments ["deadline", "by"]</li>
  * <li>Has payloads ["work on CS2113", ["Sunday"]</li>
  * <br>
- * Further, we define the FIRST command to be the MAIN command of any given user input. <br>
- * So, <code>"deadline work on CS2113 --by Sunday"</code> has <code>"deadline work on CS2113"</code>
- * as the main command
  */
 public class CommandParser {
 
@@ -47,7 +44,7 @@ public class CommandParser {
             throw new BadCommandException(ERROR_EMPTY_COMMAND);
         }
 
-        String[] commands = fullCommandString.split(ARGUMENT_DELIMITER, -1);
+        String[] rawCommands = fullCommandString.split(ARGUMENT_DELIMITER, -1);
         // Adversarial user input check
         // There are 2 possible adversarial inputs that should be checked for
         // 1. Whitespace/Empty Arguments: `cmd payload -- payload1 -- `
@@ -58,13 +55,14 @@ public class CommandParser {
         //    Split renders this as ["--argument payload"]
         //    So, check for "--" prefix
 
-        String[] cleanCommands = new String[commands.length];
-        for (int i = 0; i < commands.length; ++i) {
-            String currentCommand = commands[i];
+        String[] cleanCommands = new String[rawCommands.length];
+        for (int i = 0; i < rawCommands.length; ++i) {
+            String currentCommand = rawCommands[i];
             // Case 1 check
             if (currentCommand.startsWith(" ") || currentCommand.length() == 0) {
                 throw new BadCommandException(ERROR_EMPTY_ARGUMENT);
             }
+            // Strip command of whitespace to clean input
             currentCommand = currentCommand.strip();
             // Case 2 check
             if (currentCommand.startsWith(UNPADDED_DELIMITER)) {

--- a/src/test/java/seedu/duke/command/CommandParserTest.java
+++ b/src/test/java/seedu/duke/command/CommandParserTest.java
@@ -3,38 +3,39 @@ package seedu.duke.command;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CommandParserTest {
 
 
     @Test
-    public void parseUserInput_ValidInput() {
+    public void parseUserInput_validInput() {
         // The following commands should be able to pass
-        String[] VALID_COMMAND_INPUTS = {
-                "mainCommand",
-                "mainCommand payload",
-                "main --arg1 pay1",
-                "main --arg1 pay1 --arg2",
-                "main --arg1 pay1 --arg2 --arg3 pay3",
+        String[] validCommandInputs = {
+            "mainCommand",
+            "mainCommand payload",
+            "main --arg1 pay1",
+            "main --arg1 pay1 --arg2",
+            "main --arg1 pay1 --arg2 --arg3 pay3",
         };
 
         // The following tests check if adversarial inputs are processed correctly
-        String[] VALID_TRICKY_INPUTS = {
-                "mainCommand pay--load",
-                "mainCommand --argument1 payload--",
-                "  mainCommand --arg--1 pay1 --arg2 pay2",
+        String[] validTrickyInputs = {
+            "mainCommand pay--load",
+            "mainCommand --argument1 payload--",
+            "  mainCommand --arg--1 pay1 --arg2 pay2",
         };
 
         CommandParser parser = new CommandParser();
-        for (String validCommand : VALID_COMMAND_INPUTS) {
+        for (String validCommand : validCommandInputs) {
             try {
                 parser.parseUserInput(validCommand);
             } catch (BadCommandException exception) {
                 fail("CommandParser threw exception on valid input:\n" + exception);
             }
         }
-        for (String validCommand : VALID_TRICKY_INPUTS) {
+        for (String validCommand : validTrickyInputs) {
             try {
                 parser.parseUserInput(validCommand);
             } catch (BadCommandException exception) {
@@ -76,7 +77,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void parseUserInput_NoMainArgument_exceptionThrown() {
+    public void parseUserInput_noMainArgument_exceptionThrown() {
         CommandParser parser = new CommandParser();
         // Test on empty user input without padding
         String command = "--arg1 payload";
@@ -92,14 +93,14 @@ public class CommandParserTest {
     }
 
     @Test
-    public void getMainArgumentTest(){
+    public void getMainArgumentTest() {
         CommandParser parser = new CommandParser();
         String target = "mainCommand";
         String command = "mainCommand payload --argument payload1";
         try {
             String result1 = parser.getMainArgument(command);
             assertEquals(target, result1);
-        } catch(BadCommandException exception) {
+        } catch (BadCommandException exception) {
             fail(exception.getMessage());
         }
     }

--- a/src/test/java/seedu/duke/command/CommandParserTest.java
+++ b/src/test/java/seedu/duke/command/CommandParserTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class CommandParserTest {
 
-
     @Test
     public void parseUserInput_validInput() {
         // The following commands should be able to pass

--- a/src/test/java/seedu/duke/command/CommandParserTest.java
+++ b/src/test/java/seedu/duke/command/CommandParserTest.java
@@ -1,0 +1,107 @@
+package seedu.duke.command;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommandParserTest {
+
+
+    @Test
+    public void parseUserInput_ValidInput() {
+        // The following commands should be able to pass
+        String[] VALID_COMMAND_INPUTS = {
+                "mainCommand",
+                "mainCommand payload",
+                "main --arg1 pay1",
+                "main --arg1 pay1 --arg2",
+                "main --arg1 pay1 --arg2 --arg3 pay3",
+        };
+
+        // The following tests check if adversarial inputs are processed correctly
+        String[] VALID_TRICKY_INPUTS = {
+                "mainCommand pay--load",
+                "mainCommand --argument1 payload--",
+                "  mainCommand --arg--1 pay1 --arg2 pay2",
+        };
+
+        CommandParser parser = new CommandParser();
+        for (String validCommand : VALID_COMMAND_INPUTS) {
+            try {
+                parser.parseUserInput(validCommand);
+            } catch (BadCommandException exception) {
+                fail("CommandParser threw exception on valid input:\n" + exception);
+            }
+        }
+        for (String validCommand : VALID_TRICKY_INPUTS) {
+            try {
+                parser.parseUserInput(validCommand);
+            } catch (BadCommandException exception) {
+                fail("CommandParser threw exception on valid input:\n" + exception);
+            }
+        }
+    }
+
+    @Test
+    public void parseUserInput_emptyInput_exceptionThrown() {
+        CommandParser parser = new CommandParser();
+        // Test on empty user input
+        String command = "";
+        Assertions.assertThrows(BadCommandException.class, () -> {
+            parser.parseUserInput(command);
+        }, "BadCommandException was expected for input:\n" + command);
+    }
+
+    @Test
+    public void parseUserInput_emptyArgument_exceptionThrown() {
+        CommandParser parser = new CommandParser();
+        // Test on empty argument
+        String commandEmptyArg = "mainCommand payload --";
+        Assertions.assertThrows(BadCommandException.class, () -> {
+            parser.parseUserInput(commandEmptyArg);
+        }, "BadCommandException was expected for input:\n" + commandEmptyArg);
+
+        // Test on empty argument with padding
+        String commandEmptyArgPadded = "mainCommand payload -- ";
+        Assertions.assertThrows(BadCommandException.class, () -> {
+            parser.parseUserInput(commandEmptyArgPadded);
+        }, "BadCommandException was expected for input:\n" + commandEmptyArgPadded);
+
+        // Test on empty argument, payload exists
+        String emptyCmdWithPayload = "mainCommand payload -- payload1";
+        Assertions.assertThrows(BadCommandException.class, () -> {
+            parser.parseUserInput(emptyCmdWithPayload);
+        }, "BadCommandException was expected for input:\n" + emptyCmdWithPayload);
+    }
+
+    @Test
+    public void parseUserInput_NoMainArgument_exceptionThrown() {
+        CommandParser parser = new CommandParser();
+        // Test on empty user input without padding
+        String command = "--arg1 payload";
+        Assertions.assertThrows(BadCommandException.class, () -> {
+            parser.parseUserInput(command);
+        }, "BadCommandException was expected for input:\n" + command);
+
+        // Test on empty user input with padding
+        String commandPadded = " --arg1 payload";
+        Assertions.assertThrows(BadCommandException.class, () -> {
+            parser.parseUserInput(commandPadded);
+        }, "BadCommandException was expected for input:\n" + commandPadded);
+    }
+
+    @Test
+    public void getMainArgumentTest(){
+        CommandParser parser = new CommandParser();
+        String target = "mainCommand";
+        String command = "mainCommand payload --argument payload1";
+        try {
+            String result1 = parser.getMainArgument(command);
+            assertEquals(target, result1);
+        } catch(BadCommandException exception) {
+            fail(exception.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
This closes #15 .

### Changes
1. Added a `command` package to WellNus
2. Added CommandParser logic which processes string representing user input
- `parseuserInput` logically divides it into argument-payload pairs via a `HashMap` 
- `getMainArgument` provides a useful utility for any caller to get the main argument (action) from a command input string
3. Added in unit tests for public CommandParser methods, accounting for many adversarial test cases

