### PR TITLE
Fix getMainException unthrowable error

### DIFF
--- a/src/main/java/seedu/duke/command/CommandParser.java
+++ b/src/main/java/seedu/duke/command/CommandParser.java
@@ -138,10 +138,10 @@ public class CommandParser {
      */
     public String getMainArgument(String userInput) throws BadCommandException {
         userInput = userInput.strip();
-        String[] parameters = userInput.split(" ");
-        if (parameters.length == 0) {
+        if (userInput.length() == 0) {
             throw new BadCommandException(ERROR_EMPTY_COMMAND);
         }
+        String[] parameters = userInput.split(" ");
         return parameters[0];
     }
 

--- a/src/test/java/seedu/duke/command/CommandParserTest.java
+++ b/src/test/java/seedu/duke/command/CommandParserTest.java
@@ -3,7 +3,9 @@ package seedu.duke.command;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CommandParserTest {
 
@@ -104,7 +106,7 @@ public class CommandParserTest {
     }
 
     /**
-     *  Test that getMainArgument works for valid whitespace padded input
+     * Test that getMainArgument works for valid whitespace padded input
      */
     @Test
     public void getMainArgumentTest_paddedInput_success() {
@@ -120,7 +122,7 @@ public class CommandParserTest {
     }
 
     /**
-     *  Test that getMainArgument works for valid \n, \t padded input
+     * Test that getMainArgument works for valid \n, \t padded input
      */
     @Test
     public void getMainArgumentTest_specialWhitespace_success() {
@@ -136,7 +138,7 @@ public class CommandParserTest {
     }
 
     /**
-     *  Test that getMainArgument throws exception for empty input
+     * Test that getMainArgument throws exception for empty input
      */
     @Test
     public void getMainArgument_emptyInput_throwsException() {
@@ -147,7 +149,7 @@ public class CommandParserTest {
     }
 
     /**
-     *  Test that getMainArgument throws exception for whitespace-only input
+     * Test that getMainArgument throws exception for whitespace-only input
      */
     @Test
     public void getMainArgument_whiteSpacedInput_throwsException() {

--- a/src/test/java/seedu/duke/command/CommandParserTest.java
+++ b/src/test/java/seedu/duke/command/CommandParserTest.java
@@ -3,8 +3,7 @@ package seedu.duke.command;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CommandParserTest {
 
@@ -102,6 +101,60 @@ public class CommandParserTest {
         } catch (BadCommandException exception) {
             fail(exception.getMessage());
         }
+    }
+
+    /**
+     *  Test that getMainArgument works for valid whitespace padded input
+     */
+    @Test
+    public void getMainArgumentTest_paddedInput_success() {
+        CommandParser parser = new CommandParser();
+        String target = "mainCommand";
+        String command = "   mainCommand payload --argument payload1";
+        try {
+            String result1 = parser.getMainArgument(command);
+            assertEquals(target, result1);
+        } catch (BadCommandException exception) {
+            fail(exception.getMessage());
+        }
+    }
+
+    /**
+     *  Test that getMainArgument works for valid \n, \t padded input
+     */
+    @Test
+    public void getMainArgumentTest_specialWhitespace_success() {
+        CommandParser parser = new CommandParser();
+        String target = "mainCommand";
+        String command = "\n \t mainCommand payload --argument payload1";
+        try {
+            String result1 = parser.getMainArgument(command);
+            assertEquals(target, result1);
+        } catch (BadCommandException exception) {
+            fail(exception.getMessage());
+        }
+    }
+
+    /**
+     *  Test that getMainArgument throws exception for empty input
+     */
+    @Test
+    public void getMainArgument_emptyInput_throwsException() {
+        CommandParser parser = new CommandParser();
+        assertThrows(BadCommandException.class, () -> {
+            parser.getMainArgument("");
+        }, "Expected error throw from empty user input");
+    }
+
+    /**
+     *  Test that getMainArgument throws exception for whitespace-only input
+     */
+    @Test
+    public void getMainArgument_whiteSpacedInput_throwsException() {
+        CommandParser parser = new CommandParser();
+        assertThrows(BadCommandException.class, () -> {
+            parser.getMainArgument(" \n \t ");
+        }, "Expected error throw from white-spaced user input");
     }
 
 }


### PR DESCRIPTION
This fixes #40 

## Changelog
- Fixed the bug causing empty inputs not being detected and throwing the appropriate error
- Added more unit tests to check that the guard clause works as expected