### PR TITLE
Fix AboutUs picture rendering bug

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -1,9 +1,9 @@
 # About us
 
-| Display                                             |           Name             |            Github Profile                  |             Portfolio              |
-|-----------------------------------------------------|:--------------------------:|:-------------------------------------:     |:---------------------------------: |
-| ![](./team/wenxin.jpg)                              |        Chen Wenxin         | [Github](https://github.com/wenxin-c)      | [Portfolio](docs/team/wenxin.md)   |
-| ![](./team/WangHaoyang.png)                         |        Wang Haoyang        | [Github](https://github.com/haoyangw)      | [Portfolio](docs/team/haoyangw.md) |
-| ![](./team/yongbin.png)                             |        Wang Yongbin        | [Github](https://github.com/YongbinWang)   | [Portfolio](docs/team/yongbin.md)  |
-| ![](./team/bernard.jpg)                       |   Bernard Lesley Efendy    | [Github](https://github.com/BernardLesley) | [Portfolio](docs/team/bernard.md)  |
-| ![Yek Jin Teck, Nicholas](./team/nichyjt.jpg)       |   Yek Jin Teck, Nicholas   |  [Github](https://github.com/nichyjt)      | [Portfolio](docs/team/nichyjt.md)  |
+| Display                                       |           Name             |            Github Profile                  |             Portfolio              |
+|-----------------------------------------------|:--------------------------:|:-------------------------------------:     |:---------------------------------: |
+| ![Chen Wenxin](./team/wenxin.jpg)             |        Chen Wenxin         | [Github](https://github.com/wenxin-c)      | [Portfolio](docs/team/wenxin.md)   |
+| ![Wang Haoyang](./team/WangHaoyang.png)       |        Wang Haoyang        | [Github](https://github.com/haoyangw)      | [Portfolio](docs/team/haoyangw.md) |
+| ![Wang Yongbin](./team/yongbin.png)           |        Wang Yongbin        | [Github](https://github.com/YongbinWang)   | [Portfolio](docs/team/yongbin.md)  |
+| ![Bernard Lesley](./team/Bernard.jpg)         |   Bernard Lesley Efendy    | [Github](https://github.com/BernardLesley) | [Portfolio](docs/team/bernard.md)  |
+| ![Yek Jin Teck, Nicholas](./team/nichyjt.jpg) |   Yek Jin Teck, Nicholas   |  [Github](https://github.com/nichyjt)      | [Portfolio](docs/team/nichyjt.md)  |


### PR DESCRIPTION
This fixes #37.

## Changelog
- Fixed picture not rendering properly issue
- Added picture labels that will show the developer names if the picture fails to render