### PR TITLE
Fix atomic habit commands

### DIFF
--- a/src/main/java/wellnus/atomichabit/command/AddCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/AddCommand.java
@@ -116,8 +116,7 @@ public class AddCommand extends Command {
         if (arguments.size() != AddCommand.COMMAND_NUM_OF_ARGUMENTS) {
             throw new BadCommandException(AddCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
         }
-        String givenCommandKeyword = arguments.get(AtomicHabitManager.FEATURE_NAME);
-        if (!givenCommandKeyword.equals(AddCommand.COMMAND_KEYWORD)) {
+        if (!arguments.containsKey(AddCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(AddCommand.COMMAND_WRONG_KEYWORD_MESSAGE);
         }
         String name = arguments.get(AddCommand.COMMAND_NAME_ARGUMENT);

--- a/src/main/java/wellnus/atomichabit/command/ExitCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/ExitCommand.java
@@ -116,8 +116,7 @@ public class ExitCommand extends Command {
         if (arguments.size() != ExitCommand.COMMAND_NUM_OF_ARGUMENTS) {
             throw new BadCommandException(ExitCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
         }
-        String commandKeyword = arguments.get(AtomicHabitManager.FEATURE_NAME);
-        if (!commandKeyword.equals(ExitCommand.COMMAND_KEYWORD)) {
+        if (!arguments.containsKey(ExitCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(ExitCommand.COMMAND_INVALID_COMMAND_MESSAGE);
         }
     }

--- a/src/main/java/wellnus/atomichabit/command/ListCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/ListCommand.java
@@ -109,8 +109,7 @@ public class ListCommand extends Command {
      */
     @Override
     public void validateCommand(HashMap<String, String> arguments) throws BadCommandException {
-        String commandKeyword = arguments.get(AtomicHabitManager.FEATURE_NAME);
-        if (!commandKeyword.equals(ListCommand.COMMAND_KEYWORD)) {
+        if (!arguments.containsKey(ListCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(ListCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
         }
     }

--- a/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
@@ -180,8 +180,7 @@ public class UpdateCommand extends Command {
      */
     @Override
     public void validateCommand(HashMap<String, String> arguments) throws BadCommandException {
-        String commandKeyword = arguments.get(AtomicHabitManager.FEATURE_NAME);
-        if (!commandKeyword.equals(UpdateCommand.COMMAND_KEYWORD)) {
+        if (!arguments.containsKey(UpdateCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(UpdateCommand.COMMAND_INVALID_COMMAND_MESSAGE);
         }
         if (arguments.size() < UpdateCommand.COMMAND_MIN_NUM_OF_ARGUMENTS) {

--- a/src/main/java/wellnus/atomichabit/feature/AtomicHabitManager.java
+++ b/src/main/java/wellnus/atomichabit/feature/AtomicHabitManager.java
@@ -44,10 +44,7 @@ public class AtomicHabitManager extends Manager {
      */
     private Command getCommandFor(String commandString) throws BadCommandException {
         HashMap<String, String> arguments = getCommandParser().parseUserInput(commandString);
-        if (!arguments.containsKey(AtomicHabitManager.FEATURE_NAME)) {
-            throw new BadCommandException(UNKNOWN_COMMAND_MESSAGE);
-        }
-        String commandKeyword = arguments.get(AtomicHabitManager.FEATURE_NAME);
+        String commandKeyword = getCommandParser().getMainArgument(commandString);
         switch (commandKeyword) {
         case ADD_COMMAND_KEYWORD:
             return new AddCommand(arguments, getHabitList());

--- a/src/test/java/wellnus/atomichabit/AtomicHabitTest.java
+++ b/src/test/java/wellnus/atomichabit/AtomicHabitTest.java
@@ -18,7 +18,8 @@ import java.io.PrintStream;
 import java.util.HashMap;
 
 public class AtomicHabitTest {
-    private static final String UPDATE_HABIT_COMMAND = "hb update";
+    private static final String ADD_HABIT_COMMAND = "add";
+    private static final String UPDATE_HABIT_COMMAND = "update";
     private final AtomicHabitList habitList;
     private final ByteArrayOutputStream outputStreamCaptor;
     private final CommandParser parser;
@@ -63,7 +64,7 @@ public class AtomicHabitTest {
                 + payload
                 + "'"
                 + " was successfully added";
-        String testCommand = "hb add --name " + payload;
+        String testCommand = String.format("%s --name %s", ADD_HABIT_COMMAND, payload);
         HashMap<String, String> arguments = parser.parseUserInput(testCommand);
         Command command = new AddCommand(arguments, habitList);
         command.execute();


### PR DESCRIPTION
Wrongly required the feature keyword `hb` in front of all commands given in atomic habits' `Manager` user interface.

Remove this requirement so it matches behaviour in other features, as users would expect.