### PR TITLE
Support reflect commands

### DIFF
--- a/src/main/java/wellnus/common/MainManager.java
+++ b/src/main/java/wellnus/common/MainManager.java
@@ -8,6 +8,7 @@ import wellnus.command.HelpCommand;
 import wellnus.exception.BadCommandException;
 import wellnus.exception.WellNusException;
 import wellnus.manager.Manager;
+import wellnus.reflection.ReflectionManager;
 import wellnus.ui.TextUi;
 
 import java.util.ArrayList;
@@ -213,6 +214,7 @@ public class MainManager extends Manager {
      */
     protected void setSupportedFeatureManagers() {
         this.getSupportedFeatureManagers().add(new AtomicHabitManager());
+        this.getSupportedFeatureManagers().add(new ReflectionManager());
         // TODO: Implement once all Managers are in
         // e.g. this.getSupportedFeatureManagers().add(new AtomicHabitManager());
     }

--- a/src/main/java/wellnus/reflection/ExitCommand.java
+++ b/src/main/java/wellnus/reflection/ExitCommand.java
@@ -6,7 +6,7 @@ import wellnus.exception.BadCommandException;
 import java.util.HashMap;
 
 public class ExitCommand extends Command {
-    private static final String FEATURE_NAME = "Self Reflection";
+    private static final String FEATURE_NAME = "reflect";
     private static final String COMMAND_KEYWORD = "exit";
     private static final String FULL_DESCRIPTION = "";
     private static final String ARGUMENT = "exit";

--- a/src/main/java/wellnus/reflection/GetCommand.java
+++ b/src/main/java/wellnus/reflection/GetCommand.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 public class GetCommand extends Command {
     private static final int NUM_OF_RANDOM_QUESTIONS = 5;
-    private static final String FEATURE_NAME = "Self Reflection";
+    private static final String FEATURE_NAME = "reflect";
     private static final String COMMAND_KEYWORD = "get";
     private static final String FULL_DESCRIPTION = "";
     private static final String ARGUMENT = "get";

--- a/src/main/java/wellnus/reflection/ReflectionManager.java
+++ b/src/main/java/wellnus/reflection/ReflectionManager.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.NoSuchElementException;
 
 public class ReflectionManager extends Manager {
-    private static final String FEATURE_NAME = "Self Reflection";
+    private static final String FEATURE_NAME = "reflect";
     private static final String BRIEF_DESCRIPTION = "Users can get a random set of questions to reflect on.";
     private static final String FULL_DESCRIPTION = "";
     private static final String GET_COMMAND = "get";

--- a/src/main/java/wellnus/reflection/ReturnCommand.java
+++ b/src/main/java/wellnus/reflection/ReturnCommand.java
@@ -6,7 +6,7 @@ import wellnus.exception.BadCommandException;
 import java.util.HashMap;
 
 public class ReturnCommand extends Command {
-    private static final String FEATURE_NAME = "Self Reflection";
+    private static final String FEATURE_NAME = "reflect";
     private static final String COMMAND_KEYWORD = "return";
     private static final String FULL_DESCRIPTION = "";
     private static final String ARGUMENT = "return";


### PR DESCRIPTION
Update `MainManager` to support the self reflection feature via `ReflectionManager`.

Had to change the `FEATURE_NAME` attribute for reflect's `Command` classes, @wenxin-c are you agreeable? This is meant as a common way for `MainManager` to activate feature `Manager`s while keeping the logic abstract(and encapsulated in the feature's `Manager`)