### PR TITLE
Fix crash in GetCommand of reflections feature

### DIFF
--- a/src/main/java/wellnus/reflection/GetCommand.java
+++ b/src/main/java/wellnus/reflection/GetCommand.java
@@ -159,7 +159,7 @@ public class GetCommand extends Command {
      * @return Single string that consists of all questions
      */
     private String convertQuestionsToString() {
-        ArrayList selectedQuestions = getRandomQuestions();
+        ArrayList<ReflectionQuestion> selectedQuestions = getRandomQuestions();
         String questionString = "";
         for (int i = 0; i < selectedQuestions.size(); i += 1) {
             questionString += (Integer.toString(i + 1) + selectedQuestions.get(i).toString()

--- a/src/main/java/wellnus/reflection/GetCommand.java
+++ b/src/main/java/wellnus/reflection/GetCommand.java
@@ -58,7 +58,8 @@ public class GetCommand extends Command {
      */
     public ArrayList<ReflectionQuestion> getRandomQuestions() {
         ArrayList<ReflectionQuestion> selectedQuestions = new ArrayList<>();
-        ArrayList<ReflectionQuestion> questions = SelfReflection.getQuestions();
+        SelfReflection selfReflection = new SelfReflection();
+        ArrayList<ReflectionQuestion> questions = selfReflection.getQuestions();
         Set<Integer> fiveRandomNumbers = generateRandomNumbers(questions.size());
         for (int index : fiveRandomNumbers) {
             selectedQuestions.add(questions.get(index));

--- a/src/main/java/wellnus/reflection/SelfReflection.java
+++ b/src/main/java/wellnus/reflection/SelfReflection.java
@@ -70,6 +70,7 @@ public class SelfReflection {
     }
 
     public static ArrayList<ReflectionQuestion> getQuestions() {
+        assert questions.size() != 0 : "SelfReflection should never contain 0 questions, check your code logic";
         return questions;
     }
 

--- a/src/main/java/wellnus/reflection/SelfReflection.java
+++ b/src/main/java/wellnus/reflection/SelfReflection.java
@@ -70,7 +70,6 @@ public class SelfReflection {
     }
 
     public static ArrayList<ReflectionQuestion> getQuestions() {
-        assert questions.size() != 0 : "SelfReflection should never contain 0 questions, check your code logic";
         return questions;
     }
 

--- a/src/test/java/wellnus/reflection/GetCommandTest.java
+++ b/src/test/java/wellnus/reflection/GetCommandTest.java
@@ -37,7 +37,6 @@ class GetCommandTest {
         reflectManager.setArgumentPayload(GET_COMMAND);
         HashMap<String, String> getCmdArgumentPayload = reflectManager.getArgumentPayload();
         GetCommand get = new GetCommand(getCmdArgumentPayload);
-        SelfReflection selfReflection = new SelfReflection();
         ArrayList<ReflectionQuestion> selectedQuestions = get.getRandomQuestions();
         assertEquals(EXPECTED_ARRAY_LENGTH, selectedQuestions.size());
         SelfReflection.clearQuestions();


### PR DESCRIPTION
Fix missing constructor call to `SelfReflection` that leads to program crash when you call the `get` command of the self reflections feature.

A related issue that I feel the team should discuss is #85 