### PR TITLE
Bug get reflect question parameter bug

### DIFF
--- a/src/main/java/wellnus/reflection/ExitCommand.java
+++ b/src/main/java/wellnus/reflection/ExitCommand.java
@@ -79,6 +79,7 @@ public class ExitCommand extends Command {
             validateCommand(this.argumentPayload);
         } catch (BadCommandException invalidCommandException) {
             UI.printErrorFor(invalidCommandException, INVALID_COMMAND_NOTES);
+            return;
         }
         assert argumentPayload.containsKey(COMMAND_KEYWORD) : COMMAND_KEYWORD_ASSERTION;
         assert argumentPayload.get(COMMAND_KEYWORD).equals(PAYLOAD) : COMMAND_PAYLOAD_ASSERTION;

--- a/src/main/java/wellnus/reflection/GetCommand.java
+++ b/src/main/java/wellnus/reflection/GetCommand.java
@@ -132,7 +132,7 @@ public class GetCommand extends Command {
             throw new BadCommandException(INVALID_COMMAND_MSG);
         } else if (!commandMap.containsKey(COMMAND_KEYWORD)) {
             throw new BadCommandException(INVALID_COMMAND_MSG);
-        } else if (!(commandMap.get(COMMAND_KEYWORD).equals(PAYLOAD))) {
+        } else if (!commandMap.get(COMMAND_KEYWORD).equals(PAYLOAD)) {
             throw new BadCommandException(INVALID_COMMAND_MSG);
         }
     }

--- a/src/main/java/wellnus/reflection/GetCommand.java
+++ b/src/main/java/wellnus/reflection/GetCommand.java
@@ -44,6 +44,7 @@ public class GetCommand extends Command {
             validateCommand(this.argumentPayload);
         } catch (BadCommandException invalidCommandException) {
             UI.printErrorFor(invalidCommandException, INVALID_COMMAND_NOTES);
+            return;
         }
         assert argumentPayload.containsKey(COMMAND_KEYWORD) : COMMAND_KEYWORD_ASSERTION;
         assert argumentPayload.get(COMMAND_KEYWORD).equals(PAYLOAD) : COMMAND_PAYLOAD_ASSERTION;
@@ -131,7 +132,7 @@ public class GetCommand extends Command {
             throw new BadCommandException(INVALID_COMMAND_MSG);
         } else if (!commandMap.containsKey(COMMAND_KEYWORD)) {
             throw new BadCommandException(INVALID_COMMAND_MSG);
-        } else if (!commandMap.get(COMMAND_KEYWORD).equals(PAYLOAD)) {
+        } else if (!(commandMap.get(COMMAND_KEYWORD).equals(PAYLOAD))) {
             throw new BadCommandException(INVALID_COMMAND_MSG);
         }
     }

--- a/src/main/java/wellnus/reflection/ReturnCommand.java
+++ b/src/main/java/wellnus/reflection/ReturnCommand.java
@@ -105,7 +105,7 @@ public class ReturnCommand extends Command {
             throw new BadCommandException(INVALID_COMMAND_MSG);
         } else if (!commandMap.containsKey(COMMAND_KEYWORD)) {
             throw new BadCommandException(INVALID_COMMAND_MSG);
-        } else if (!(commandMap.get(COMMAND_KEYWORD).equals(PAYLOAD))) {
+        } else if (!commandMap.get(COMMAND_KEYWORD).equals(PAYLOAD)) {
             throw new BadCommandException(INVALID_COMMAND_MSG);
         }
     }

--- a/src/main/java/wellnus/reflection/ReturnCommand.java
+++ b/src/main/java/wellnus/reflection/ReturnCommand.java
@@ -80,6 +80,7 @@ public class ReturnCommand extends Command {
             validateCommand(this.argumentPayload);
         } catch (BadCommandException invalidCommandException) {
             UI.printErrorFor(invalidCommandException, INVALID_COMMAND_NOTES);
+            return;
         }
         assert argumentPayload.containsKey(COMMAND_KEYWORD) : COMMAND_KEYWORD_ASSERTION;
         assert argumentPayload.get(COMMAND_KEYWORD).equals(PAYLOAD) : COMMAND_PAYLOAD_ASSERTION;


### PR DESCRIPTION
Fixes #98 
Adding ```return;``` in catch block after a BadCommandException is caught to return back to main loop. In this way, the ```execute()```method will not continue executing. 