### PR TITLE
BugFix-Defensive Home Command Habit

### DIFF
--- a/src/main/java/wellnus/atomichabit/command/HomeCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/HomeCommand.java
@@ -116,6 +116,9 @@ public class HomeCommand extends Command {
         if (arguments.size() != HomeCommand.COMMAND_NUM_OF_ARGUMENTS) {
             throw new BadCommandException(HomeCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
         }
+        if (arguments.get(COMMAND_KEYWORD) != "") {
+            throw new BadCommandException(HomeCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
+        }
         if (!arguments.containsKey(HomeCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(HomeCommand.COMMAND_INVALID_COMMAND_MESSAGE);
         }


### PR DESCRIPTION
This resolves #117 

Throw `BadCommandException()` if the first argument has a value pair in the hash map