### PR TITLE
Define Tokenizer interface

### DIFF
--- a/src/main/java/wellnus/exception/TokenizerException.java
+++ b/src/main/java/wellnus/exception/TokenizerException.java
@@ -1,0 +1,7 @@
+package wellnus.exception;
+
+public class TokenizerException extends WellNusException {
+    public TokenizerException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/wellnus/exception/TokenizerException.java
+++ b/src/main/java/wellnus/exception/TokenizerException.java
@@ -1,6 +1,14 @@
 package wellnus.exception;
 
+/**
+ * Category of Exceptions related to the <code>Tokenizer</code> interface and its operations/subclasses.
+ * @see wellnus.storage.Tokenizer
+ */
 public class TokenizerException extends WellNusException {
+    /**
+     * Initializes an instance of TokenizerException with the given error message.
+     * @param errorMessage Error message to show to the user
+     */
     public TokenizerException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/main/java/wellnus/storage/Tokenizer.java
+++ b/src/main/java/wellnus/storage/Tokenizer.java
@@ -1,0 +1,37 @@
+package wellnus.storage;
+
+import wellnus.exception.TokenizerException;
+import wellnus.manager.Manager;
+
+import java.util.ArrayList;
+
+/**
+ * Template for all Tokenizers in WellNUS++ that are responsible for converting
+ *     Managers into Strings(for storage) and also Strings(from storage) back
+ *     into Managers with the previously saved state.<br/>
+ *
+ * Example of how to implement this in a feature: <code>public class AtomicHabitTokenizer
+ *     implements Tokenizer&lt;AtomicHabit&gt;</code>.
+ * @param <T> Data type of the corresponding feature, e.g. <code>AtomicHabit</code>
+ *     the atomic habit feature
+ */
+public interface Tokenizer<T> {
+    /**
+     * Converts the attributes of the given <code>Manager</code> into a String representation to be
+     *     saved to storage.
+     * @param managerToTokenize Manager whose state we want to convert into a String representation
+     * @throws TokenizerException If tokenizing fails and state cannot be converted into a valid String
+     *     representation
+     */
+    String tokenize(Manager managerToTokenize) throws TokenizerException;
+
+    /**
+     * Converts the String representation of a <code>Manager</code>'s state back into an
+     *     <code>ArrayList</code> of the feature's data type class that can be used to restore that
+     *     <code>Manager</code>'s previous state.
+     * @param tokenizedManager String representation of the Manager whose state we want to restore
+     * @return ArrayList containing all the data from the Manager's previously saved state
+     * @throws TokenizerException If detokenizing fails and valid state cannot be restored
+     */
+    ArrayList<T> detokenize(String tokenizedManager) throws TokenizerException;
+}

--- a/src/main/java/wellnus/storage/Tokenizer.java
+++ b/src/main/java/wellnus/storage/Tokenizer.java
@@ -1,9 +1,9 @@
 package wellnus.storage;
 
+import java.util.ArrayList;
+
 import wellnus.exception.TokenizerException;
 import wellnus.manager.Manager;
-
-import java.util.ArrayList;
 
 /**
  * Template for all Tokenizers in WellNUS++ that are responsible for converting


### PR DESCRIPTION
Individual features all have different ways of converting state(of their `Manager`) into `String` representations, and from `String` representations back into the saved state. So the exact implementation of these operations can be left abstract.

That being said, we do want expect all implementations to have the same input and output(the same 'black box' representation of their operations), so all features shall provide the same method signatures for their `tokenize()` and `detokenize()` operations.

Hence, the need for a `Tokenizer` interface.

This closes #132. 