### PR TITLE
Enable assertions for team repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }


### PR DESCRIPTION
Fixes #141 
Enable assertions in ```build.gradle```
This is a weekly task required. 