### PR TITLE
Fix home command assertion misplacement bug

### DIFF
--- a/src/main/java/wellnus/reflection/HomeCommand.java
+++ b/src/main/java/wellnus/reflection/HomeCommand.java
@@ -28,6 +28,7 @@ public class HomeCommand extends Command {
     private static final String COMMAND_PAYLOAD_ASSERTION = "The payload should be empty.";
     private static final String HOME_MESSAGE = "How do you feel after reflecting on yourself?"
             + System.lineSeparator() + "Hope you have gotten some takeaways from self reflection, see you again!!";
+    private static final String IS_EXIT_ASSERTION = "isExit should be true after exiting while loop";
     private HashMap<String, String> argumentPayload;
 
     /**
@@ -100,6 +101,7 @@ public class HomeCommand extends Command {
         assert argumentPayload.get(COMMAND_KEYWORD).equals(PAYLOAD) : COMMAND_PAYLOAD_ASSERTION;
         UI.printOutputMessage(HOME_MESSAGE);
         ReflectionManager.setIsExit(true);
+        assert ReflectionManager.getIsExit() : IS_EXIT_ASSERTION;
     }
 
     /**

--- a/src/main/java/wellnus/reflection/ReflectionManager.java
+++ b/src/main/java/wellnus/reflection/ReflectionManager.java
@@ -24,7 +24,6 @@ public class ReflectionManager extends Manager {
     private static final String NO_ELEMENT_MESSAGE = "There is no new line of input, please key in inputs.";
     private static final String INVALID_COMMAND_MESSAGE = "Please check the available commands "
             + "and enter a valid command.";
-    private static final String IS_EXIT_ASSERTION = "isExit should be true after exiting while loop";
     private static final int EMPTY_COMMAND = 0;
     private static final String COMMAND_TYPE_ASSERTION = "Command type should have length greater than 0";
 
@@ -186,7 +185,6 @@ public class ReflectionManager extends Manager {
         case HOME_COMMAND:
             HomeCommand returnCmd = new HomeCommand(argumentPayload);
             returnCmd.execute();
-            assert isExit : IS_EXIT_ASSERTION;
             break;
         default:
             throw new BadCommandException(INVALID_COMMAND_MESSAGE);


### PR DESCRIPTION
Fixes #116 
The assumption that ```isExit == true``` after ```.execute()``` is wrong. Move the the assertion to after ```setIsExit(true)``` will fix the issue. 