### PR TITLE
Ignore case for `CommandParser` arguments

### DIFF
--- a/src/main/java/wellnus/command/CommandParser.java
+++ b/src/main/java/wellnus/command/CommandParser.java
@@ -103,7 +103,7 @@ public class CommandParser {
             logger.log(Level.INFO, LOG_STR_EMPTY_INPUT);
             throw new BadCommandException(ERROR_EMPTY_ARGUMENT);
         }
-        return words[0];
+        return words[0].toLowerCase();
     }
 
     private String getPayloadFromCommand(String commandString) {
@@ -154,7 +154,7 @@ public class CommandParser {
      * Has main argument "hb"
      *
      * @param userInput Any string input representing a command
-     * @return the inferred Main Argument
+     * @return the inferred Main Argument, converted to lowercase
      * @throws BadCommandException when String is empty
      */
     public String getMainArgument(String userInput) throws BadCommandException {
@@ -166,6 +166,6 @@ public class CommandParser {
             throw new BadCommandException(ERROR_EMPTY_COMMAND);
         }
         String[] parameters = userInput.split(" ");
-        return parameters[0];
+        return parameters[0].toLowerCase();
     }
 }

--- a/src/main/java/wellnus/command/CommandParser.java
+++ b/src/main/java/wellnus/command/CommandParser.java
@@ -52,6 +52,25 @@ public class CommandParser {
 
     }
 
+    /**
+     * Split a userInput by the standardized delimiter.
+     * <p>
+     * This function handles some adversarial user input.
+     * There are 2 possible adversarial inputs that this function checks for:
+     * <p>
+     * 1. Whitespace/Empty Arguments: `cmd payload -- payload1 -- ` <br>
+     * Split renders it as ["cmd payload", " payload1", ""]
+     * " payload1" will cause issues with rendering
+     * So, check for empty commands and whitespace prefix. <br>
+     * <p>
+     * 2. Missing main argument: `--argument payload` <br>
+     * Split renders this as ["--argument payload"]
+     * So, check for "--" prefix.
+     *
+     * @param fullCommandString Raw user input from stdin in string form
+     * @return String array of command substrings
+     * @throws BadCommandException when command is empty or is problematic
+     */
     private String[] splitIntoCommands(String fullCommandString) throws BadCommandException {
         assert fullCommandString != null : "fullCommandString should not be null";
 
@@ -64,16 +83,6 @@ public class CommandParser {
 
         int noLimit = -1;
         String[] rawCommands = fullCommandString.split(ARGUMENT_DELIMITER, noLimit);
-        // Adversarial user input check
-        // There are 2 possible adversarial inputs that should be checked for
-        // 1. Whitespace/Empty Arguments: `cmd payload -- payload1 -- `
-        //    Split renders it as ["cmd payload", " payload1", ""]
-        //    " payload1" will cause issues with rendering
-        //    So, check for empty commands and whitespace prefix
-        // 2. Missing main argument: `--argument payload`
-        //    Split renders this as ["--argument payload"]
-        //    So, check for "--" prefix
-
         String[] cleanCommands = new String[rawCommands.length];
         for (int i = 0; i < rawCommands.length; ++i) {
             String currentCommand = rawCommands[i];

--- a/src/test/java/wellnus/command/CommandParserTest.java
+++ b/src/test/java/wellnus/command/CommandParserTest.java
@@ -16,18 +16,18 @@ public class CommandParserTest {
     public void parseUserInput_validInput() {
         // The following commands should be able to pass
         String[] validCommandInputs = {
-                "mainCommand",
-                "mainCommand payload",
-                "main --arg1 pay1",
-                "main --arg1 pay1 --arg2",
-                "main --arg1 pay1 --arg2 --arg3 pay3",
+            "mainCommand",
+            "mainCommand payload",
+            "main --arg1 pay1",
+            "main --arg1 pay1 --arg2",
+            "main --arg1 pay1 --arg2 --arg3 pay3",
         };
 
         // The following tests check if adversarial inputs are processed correctly
         String[] validTrickyInputs = {
-                "mainCommand pay--load",
-                "mainCommand --argument1 payload--",
-                "  mainCommand --arg--1 pay1 --arg2 pay2",
+            "mainCommand pay--load",
+            "mainCommand --argument1 payload--",
+            "  mainCommand --arg--1 pay1 --arg2 pay2",
         };
 
         CommandParser parser = new CommandParser();

--- a/src/test/java/wellnus/command/CommandParserTest.java
+++ b/src/test/java/wellnus/command/CommandParserTest.java
@@ -16,18 +16,18 @@ public class CommandParserTest {
     public void parseUserInput_validInput() {
         // The following commands should be able to pass
         String[] validCommandInputs = {
-            "mainCommand",
-            "mainCommand payload",
-            "main --arg1 pay1",
-            "main --arg1 pay1 --arg2",
-            "main --arg1 pay1 --arg2 --arg3 pay3",
+                "mainCommand",
+                "mainCommand payload",
+                "main --arg1 pay1",
+                "main --arg1 pay1 --arg2",
+                "main --arg1 pay1 --arg2 --arg3 pay3",
         };
 
         // The following tests check if adversarial inputs are processed correctly
         String[] validTrickyInputs = {
-            "mainCommand pay--load",
-            "mainCommand --argument1 payload--",
-            "  mainCommand --arg--1 pay1 --arg2 pay2",
+                "mainCommand pay--load",
+                "mainCommand --argument1 payload--",
+                "  mainCommand --arg--1 pay1 --arg2 pay2",
         };
 
         CommandParser parser = new CommandParser();
@@ -98,7 +98,7 @@ public class CommandParserTest {
     @Test
     public void getMainArgumentTest() {
         CommandParser parser = new CommandParser();
-        String target = "mainCommand";
+        String target = "maincommand";
         String command = "mainCommand payload --argument payload1";
         try {
             String result1 = parser.getMainArgument(command);

--- a/src/test/java/wellnus/command/CommandParserTest.java
+++ b/src/test/java/wellnus/command/CommandParserTest.java
@@ -16,18 +16,18 @@ public class CommandParserTest {
     public void parseUserInput_validInput() {
         // The following commands should be able to pass
         String[] validCommandInputs = {
-            "mainCommand",
-            "mainCommand payload",
-            "main --arg1 pay1",
-            "main --arg1 pay1 --arg2",
-            "main --arg1 pay1 --arg2 --arg3 pay3",
+                "mainCommand",
+                "mainCommand payload",
+                "main --arg1 pay1",
+                "main --arg1 pay1 --arg2",
+                "main --arg1 pay1 --arg2 --arg3 pay3",
         };
 
         // The following tests check if adversarial inputs are processed correctly
         String[] validTrickyInputs = {
-            "mainCommand pay--load",
-            "mainCommand --argument1 payload--",
-            "  mainCommand --arg--1 pay1 --arg2 pay2",
+                "mainCommand pay--load",
+                "mainCommand --argument1 payload--",
+                "  mainCommand --arg--1 pay1 --arg2 pay2",
         };
 
         CommandParser parser = new CommandParser();
@@ -114,7 +114,7 @@ public class CommandParserTest {
     @Test
     public void getMainArgumentTest_paddedInput_success() {
         CommandParser parser = new CommandParser();
-        String target = "mainCommand";
+        String target = "maincommand";
         String command = "   mainCommand payload --argument payload1";
         try {
             String result1 = parser.getMainArgument(command);
@@ -130,7 +130,7 @@ public class CommandParserTest {
     @Test
     public void getMainArgumentTest_specialWhitespace_success() {
         CommandParser parser = new CommandParser();
-        String target = "mainCommand";
+        String target = "maincommand";
         String command = "\n \t mainCommand payload --argument payload1";
         try {
             String result1 = parser.getMainArgument(command);


### PR DESCRIPTION
This fixes #100.

## Changelog
- Added trim functions to methods that handle argument extraction