### PR TITLE
Fix unreliable home commands

### DIFF
--- a/src/main/java/wellnus/atomichabit/command/HomeCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/HomeCommand.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import wellnus.atomichabit.feature.AtomicHabitManager;
 import wellnus.command.Command;
 import wellnus.exception.BadCommandException;
+import wellnus.exception.WellNusException;
 import wellnus.ui.TextUi;
 
 /**
@@ -20,6 +21,8 @@ public class HomeCommand extends Command {
     private static final String COMMAND_INVALID_COMMAND_MESSAGE = "Wrong command given for home!";
     private static final String HOME_MESSAGE = "Thank you for using atomic habits. Do not forget about me!";
     private static final String NO_ADDITIONAL_MESSAGE = "";
+    private static final String WRONG_COMMAND_ARGUMENTS_MESSAGE = "'home' command shouldn't have additional '%s' "
+            + "argument";
     private final TextUi textUi;
 
     /**
@@ -72,13 +75,8 @@ public class HomeCommand extends Command {
      * Prints the exit feature message for the atomic habits feature on the user's screen.
      */
     @Override
-    public void execute() {
-        try {
-            validateCommand(super.getArguments());
-        } catch (BadCommandException badCommandException) {
-            this.getTextUi().printErrorFor(badCommandException, NO_ADDITIONAL_MESSAGE);
-            return;
-        }
+    public void execute() throws WellNusException {
+        validateCommand(super.getArguments());
         getTextUi().printOutputMessage(HOME_MESSAGE);
     }
 
@@ -104,11 +102,12 @@ public class HomeCommand extends Command {
         if (arguments.size() != HomeCommand.COMMAND_NUM_OF_ARGUMENTS) {
             throw new BadCommandException(HomeCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
         }
-        if (arguments.get(COMMAND_KEYWORD) != "") {
-            throw new BadCommandException(HomeCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
-        }
         if (!arguments.containsKey(HomeCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(HomeCommand.COMMAND_INVALID_COMMAND_MESSAGE);
+        }
+        String payload = arguments.get(getCommandKeyword());
+        if (!payload.isBlank()) {
+            throw new BadCommandException(String.format(WRONG_COMMAND_ARGUMENTS_MESSAGE, payload));
         }
     }
 

--- a/src/main/java/wellnus/focus/command/HomeCommand.java
+++ b/src/main/java/wellnus/focus/command/HomeCommand.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 
 import wellnus.command.Command;
 import wellnus.exception.BadCommandException;
+import wellnus.exception.WellNusException;
 import wellnus.focus.feature.FocusManager;
 import wellnus.focus.feature.Session;
 import wellnus.ui.TextUi;
@@ -21,6 +22,8 @@ public class HomeCommand extends Command {
     private static final String COMMAND_INVALID_COMMAND_MESSAGE = "Wrong command given for home!";
     private static final String HOME_MESSAGE = "Thank you for using focus timer. Keep up the productivity!";
     private static final String NO_ADDITIONAL_MESSAGE = "";
+    private static final String WRONG_COMMAND_ARGUMENTS_MESSAGE = "'home' command shouldn't have additional '%s' "
+            + "argument";
     private final TextUi textUi;
     private final Session session;
 
@@ -74,13 +77,8 @@ public class HomeCommand extends Command {
      * Prints the exit feature message for the focus timer feature on the user's screen.
      */
     @Override
-    public void execute() {
-        try {
-            validateCommand(super.getArguments());
-        } catch (BadCommandException badCommandException) {
-            textUi.printErrorFor(badCommandException, NO_ADDITIONAL_MESSAGE);
-            return;
-        }
+    public void execute() throws WellNusException {
+        validateCommand(super.getArguments());
         if (!session.isSessionReady()) {
             session.getCurrentCountdown().setStop();
         }
@@ -96,14 +94,15 @@ public class HomeCommand extends Command {
      */
     @Override
     public void validateCommand(HashMap<String, String> arguments) throws BadCommandException {
-        if (arguments.size() != HomeCommand.COMMAND_NUM_OF_ARGUMENTS) {
-            throw new BadCommandException(HomeCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
-        }
-        if (!arguments.get(COMMAND_KEYWORD).equals("")) {
+        if (arguments.size() > HomeCommand.COMMAND_NUM_OF_ARGUMENTS) {
             throw new BadCommandException(HomeCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
         }
         if (!arguments.containsKey(HomeCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(HomeCommand.COMMAND_INVALID_COMMAND_MESSAGE);
+        }
+        String payload = arguments.get(getCommandKeyword());
+        if (!payload.isBlank()) {
+            throw new BadCommandException(String.format(WRONG_COMMAND_ARGUMENTS_MESSAGE, payload));
         }
     }
 

--- a/src/main/java/wellnus/gamification/GamificationManager.java
+++ b/src/main/java/wellnus/gamification/GamificationManager.java
@@ -18,8 +18,8 @@ import wellnus.ui.TextUi;
  */
 public class GamificationManager extends Manager {
     public static final String FEATURE_NAME = "gamif";
-    public static final String FEATURE_HELP_DESCRIPTION = "Gamification (gamif) - Gamification gives you the motivation "
-            + "to continue improving your wellness by rewarding you for your efforts!";
+    public static final String FEATURE_HELP_DESCRIPTION = "Gamification (gamif) - Gamification gives you the "
+            + "motivation to continue improving your wellness by rewarding you for your efforts!";
     private static final String COMMAND_HELP = "help";
     private static final String COMMAND_HOME = "home";
     private static final String COMMAND_STATS = "stats";

--- a/src/main/java/wellnus/gamification/GamificationManager.java
+++ b/src/main/java/wellnus/gamification/GamificationManager.java
@@ -80,12 +80,9 @@ public class GamificationManager extends Manager {
      * <br>
      * It is calls the relevant methods to present the user with the gamification feature's interface
      * and manage the user's commands.
-     *
-     * @throws BadCommandException If an unrecognised command is given or invalid arguments are given for
-     *                             a recognised command
      */
     @Override
-    public void runEventDriver() throws BadCommandException {
+    public void runEventDriver() {
         GamificationUi.printLogo();
         boolean isExit = false;
         while (!isExit) {

--- a/src/main/java/wellnus/gamification/command/HomeCommand.java
+++ b/src/main/java/wellnus/gamification/command/HomeCommand.java
@@ -19,6 +19,7 @@ public class HomeCommand extends Command {
     private static final String TOO_MANY_ARGUMENTS_MESSAGE = "Too many arguments given";
     private static final String WRONG_COMMAND_KEYWORD_MESSAGE = "Gamification feature's HomeCommand called for the "
             + "wrong command";
+    private static final String WRONG_ARGUMENTS_MESSAGE = "'home' command shouldn't have an additional '%s' argument";
 
     /**
      * Initialises a Command Object to handle the 'home' command from the user
@@ -77,6 +78,10 @@ public class HomeCommand extends Command {
         assert arguments.containsKey(getCommandKeyword()) : WRONG_COMMAND_KEYWORD_MESSAGE;
         if (arguments.size() > NUM_OF_ARGUMENTS) {
             throw new BadCommandException(TOO_MANY_ARGUMENTS_MESSAGE);
+        }
+        String payload = arguments.get(getCommandKeyword());
+        if (!payload.isBlank()) {
+            throw new BadCommandException(String.format(WRONG_ARGUMENTS_MESSAGE, payload));
         }
     }
 

--- a/src/main/java/wellnus/reflection/command/HomeCommand.java
+++ b/src/main/java/wellnus/reflection/command/HomeCommand.java
@@ -24,10 +24,11 @@ public class HomeCommand extends Command {
     private static final String INVALID_COMMAND_MSG = "Command is invalid.";
     private static final String INVALID_COMMAND_NOTES = "Please check the available commands "
             + "and the format of commands.";
-    private static final String COMMAND_KEYWORD_ASSERTION = "The key should be return.";
     private static final String COMMAND_PAYLOAD_ASSERTION = "The payload should be empty.";
     private static final String HOME_MESSAGE = "How do you feel after reflecting on yourself?"
             + System.lineSeparator() + "Hope you have gotten some takeaways from self reflection, see you again!!";
+    private static final String WRONG_COMMAND_ARGUMENTS_MESSAGE = "'home' command shouldn't have additional '%s' "
+            + "argument";
     private static final int ARGUMENT_PAYLOAD_SIZE = 1;
     private static final ReflectUi UI = new ReflectUi();
     private QuestionList questionList;
@@ -128,10 +129,11 @@ public class HomeCommand extends Command {
             throw new BadCommandException(INVALID_COMMAND_MSG);
         } else if (!commandMap.containsKey(COMMAND_KEYWORD)) {
             throw new BadCommandException(INVALID_COMMAND_MSG);
-        } else if (!commandMap.get(COMMAND_KEYWORD).equals(PAYLOAD)) {
-            throw new BadCommandException(INVALID_COMMAND_MSG);
         }
-        assert getArguments().containsKey(COMMAND_KEYWORD) : COMMAND_KEYWORD_ASSERTION;
+        String payload = commandMap.get(getCommandKeyword());
+        if (!payload.isBlank()) {
+            throw new BadCommandException(String.format(WRONG_COMMAND_ARGUMENTS_MESSAGE, payload));
+        }
         assert getArguments().get(COMMAND_KEYWORD).equals(PAYLOAD) : COMMAND_PAYLOAD_ASSERTION;
     }
 }


### PR DESCRIPTION
Check for additional, unnecessary arguments given for `home` in atomic habits, gamification and focus timer features to make our application more robust.

Also make the error message for invalid home command in reflection feature more specific to help the user.