### PR TITLE
Fix bogus Tokenizer Exceptions

### DIFF
--- a/src/main/java/wellnus/reflection/feature/QuestionList.java
+++ b/src/main/java/wellnus/reflection/feature/QuestionList.java
@@ -78,7 +78,6 @@ public class QuestionList {
             UI.printErrorFor(storageException, STORAGE_ERROR);
         }
         this.randomQuestionIndexes = new HashSet<>();
-        this.dataIndexInitialSetup();
         try {
             this.loadQuestionData();
         } catch (StorageException storageException) {
@@ -117,18 +116,6 @@ public class QuestionList {
 
     public ArrayList<Set<Integer>> getDataIndex() {
         return dataIndex;
-    }
-
-    /**
-     * Set up initial data file.<br/>
-     * Set up the arrayList and set in the event that datafile is corrupted.
-     */
-    public void dataIndexInitialSetup() {
-        this.dataIndex = new ArrayList<>();
-        HashSet<Integer> setLike = new HashSet<>();
-        HashSet<Integer> setPrev = new HashSet<>();
-        this.dataIndex.add(setLike);
-        this.dataIndex.add(setPrev);
     }
 
     /**

--- a/src/main/java/wellnus/storage/AtomicHabitTokenizer.java
+++ b/src/main/java/wellnus/storage/AtomicHabitTokenizer.java
@@ -97,8 +97,10 @@ public class AtomicHabitTokenizer implements Tokenizer<AtomicHabit> {
     public ArrayList<AtomicHabit> detokenize(ArrayList<String> tokenizedAtomicHabits) throws TokenizerException {
         ArrayList<AtomicHabit> detokenizedAtomicHabits = new ArrayList<>();
         for (String tokenizedString : tokenizedAtomicHabits) {
-            AtomicHabit parsedHabit = parseTokenizedHabit(tokenizedString);
-            detokenizedAtomicHabits.add(parsedHabit);
+            if (!tokenizedString.isBlank()) {
+                AtomicHabit parsedHabit = parseTokenizedHabit(tokenizedString);
+                detokenizedAtomicHabits.add(parsedHabit);
+            }
         }
         return detokenizedAtomicHabits;
     }

--- a/src/main/java/wellnus/storage/ReflectionTokenizer.java
+++ b/src/main/java/wellnus/storage/ReflectionTokenizer.java
@@ -121,10 +121,16 @@ public class ReflectionTokenizer implements Tokenizer<Set<Integer>> {
         Set<Integer> detokenizedLike = new HashSet<>();
         Set<Integer> detokenizedPref = new HashSet<>();
         if (tokenizedIndex.size() == TOKENIZER_INDEX_ARRAYLIST_SIZE) {
-            String rawIndexLike = splitParameter(tokenizedIndex.get(INDEX_ZERO), LIKE_KEY);
-            String rawIndexPref = splitParameter(tokenizedIndex.get(INDEX_ONE), PREF_KEY);
-            detokenizedLike = getSet(rawIndexLike);
-            detokenizedPref = getSet(rawIndexPref);
+            String tokenizedLikedIndexes = tokenizedIndex.get(INDEX_ZERO);
+            if (!tokenizedLikedIndexes.isBlank()) {
+                String rawIndexLike = splitParameter(tokenizedLikedIndexes, LIKE_KEY);
+                detokenizedLike = getSet(rawIndexLike);
+            }
+            String tokenizedPrefIndexes = tokenizedIndex.get(INDEX_ONE);
+            if (!tokenizedPrefIndexes.isBlank()) {
+                String rawIndexPref = splitParameter(tokenizedPrefIndexes, PREF_KEY);
+                detokenizedPref = getSet(rawIndexPref);
+            }
         }
         detokenizedIndexes.add(detokenizedLike);
         detokenizedIndexes.add(detokenizedPref);


### PR DESCRIPTION
`AtomicHabitTokenizer` and `ReflectionTokenizer` now complains when their data files exist but are empty, which is not actually an issue.

Implement checks so they stop complaining so much, which is ugly.