### PR TITLE
Check `exit` command arguments

### DIFF
--- a/src/main/java/wellnus/command/ExitCommand.java
+++ b/src/main/java/wellnus/command/ExitCommand.java
@@ -3,6 +3,7 @@ package wellnus.command;
 import java.util.HashMap;
 
 import wellnus.exception.BadCommandException;
+import wellnus.exception.WellNusException;
 import wellnus.ui.TextUi;
 
 /**
@@ -13,7 +14,10 @@ public class ExitCommand extends Command {
     public static final String COMMAND_USAGE = "usage: exit";
     public static final String COMMAND_KEYWORD = "exit";
     private static final String COMMAND_INVALID_COMMAND_MESSAGE = "Invalid exit command given!";
+    private static final String EXTRA_ARGUMENTS_MESSAGE = "'exit' command not supposed to have arguments at all";
     private static final String FEATURE_KEYWORD = "";
+    private static final int NUM_OF_ARGUMENTS = 1;
+    private static final String TOO_MANY_ARGUMENTS_MESSAGE = "Too many arguments given for 'exit'";
     private final TextUi textUi;
 
     /**
@@ -61,7 +65,8 @@ public class ExitCommand extends Command {
      * Exits the WellNUS++ application.
      */
     @Override
-    public void execute() {
+    public void execute() throws WellNusException {
+        validateCommand(super.getArguments());
     }
 
     /**
@@ -74,6 +79,13 @@ public class ExitCommand extends Command {
     public void validateCommand(HashMap<String, String> arguments) throws BadCommandException {
         if (!arguments.containsKey(ExitCommand.COMMAND_KEYWORD)) {
             throw new BadCommandException(ExitCommand.COMMAND_INVALID_COMMAND_MESSAGE);
+        }
+        if (arguments.size() > NUM_OF_ARGUMENTS) {
+            throw new BadCommandException(ExitCommand.TOO_MANY_ARGUMENTS_MESSAGE);
+        }
+        String commandPayload = arguments.get(ExitCommand.COMMAND_KEYWORD);
+        if (!commandPayload.isBlank()) {
+            throw new BadCommandException(EXTRA_ARGUMENTS_MESSAGE);
         }
     }
 


### PR DESCRIPTION
Stop allowing `exit` command to succeed when extra arguments are given