### PR TITLE
Redirect logging to file

### DIFF
--- a/src/main/java/wellnus/atomichabit/command/DeleteCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/DeleteCommand.java
@@ -9,6 +9,7 @@ import wellnus.atomichabit.feature.AtomicHabit;
 import wellnus.atomichabit.feature.AtomicHabitList;
 import wellnus.atomichabit.feature.AtomicHabitManager;
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.AtomicHabitException;
 import wellnus.exception.BadCommandException;
 import wellnus.ui.TextUi;
@@ -32,7 +33,7 @@ public class DeleteCommand extends Command {
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final String DELETE_INVALID_ARGUMENTS_MESSAGE = "Invalid arguments for delete, no deletion shall "
             + "be performed.";
-    private static final Logger logger = Logger.getLogger("DeleteAtomicHabitLogger");
+    private static final Logger logger = WellNusLogger.getLogger("DeleteAtomicHabitLogger");
     private static final String LOG_STR_INPUT_NOT_INTEGER = "Input string is not an integer."
             + "This should be properly handled";
 

--- a/src/main/java/wellnus/atomichabit/command/DeleteCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/DeleteCommand.java
@@ -33,7 +33,7 @@ public class DeleteCommand extends Command {
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final String DELETE_INVALID_ARGUMENTS_MESSAGE = "Invalid arguments for delete, no deletion shall "
             + "be performed.";
-    private static final Logger logger = WellNusLogger.getLogger("DeleteAtomicHabitLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("DeleteAtomicHabitLogger");
     private static final String LOG_STR_INPUT_NOT_INTEGER = "Input string is not an integer."
             + "This should be properly handled";
 
@@ -132,10 +132,10 @@ public class DeleteCommand extends Command {
             getTextUi().printOutputMessage(FEEDBACK_STRING + LINE_SEPARATOR
                     + stringOfDeletedHabit);
         } catch (NumberFormatException numberFormatException) {
-            logger.log(Level.INFO, LOG_STR_INPUT_NOT_INTEGER);
+            LOGGER.log(Level.INFO, LOG_STR_INPUT_NOT_INTEGER);
             throw new AtomicHabitException(FEEDBACK_INDEX_NOT_INTEGER_ERROR);
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.INFO, LOG_INDEX_OUT_OF_BOUNDS);
+            LOGGER.log(Level.INFO, LOG_INDEX_OUT_OF_BOUNDS);
             throw new AtomicHabitException(FEEDBACK_INDEX_OUT_OF_BOUNDS_ERROR);
         } catch (BadCommandException badCommandException) {
             getTextUi().printErrorFor(badCommandException, NO_ADDITIONAL_MESSAGE);

--- a/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
@@ -9,6 +9,7 @@ import wellnus.atomichabit.feature.AtomicHabit;
 import wellnus.atomichabit.feature.AtomicHabitList;
 import wellnus.atomichabit.feature.AtomicHabitManager;
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.AtomicHabitException;
 import wellnus.exception.BadCommandException;
 import wellnus.gamification.util.GamificationData;
@@ -46,7 +47,7 @@ public class UpdateCommand extends Command {
     private static final String UPDATE_INVALID_INCREMENT_COUNT = "Increment with minimum of 1 is expected, no update "
             + "shall be performed.";
     private static final String REGEX_INTEGER_ONLY_PATTERN = "\\s*-?\\d+\\s*";
-    private static final Logger logger = Logger.getLogger("UpdateAtomicHabitLogger");
+    private static final Logger logger = WellNusLogger.getLogger("UpdateAtomicHabitLogger");
     private static final String LOG_STR_INPUT_NOT_INTEGER = "Input string is not an integer."
             + "This should be properly handled";
 

--- a/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
@@ -47,7 +47,7 @@ public class UpdateCommand extends Command {
     private static final String UPDATE_INVALID_INCREMENT_COUNT = "Increment with minimum of 1 is expected, no update "
             + "shall be performed.";
     private static final String REGEX_INTEGER_ONLY_PATTERN = "\\s*-?\\d+\\s*";
-    private static final Logger logger = WellNusLogger.getLogger("UpdateAtomicHabitLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("UpdateAtomicHabitLogger");
     private static final String LOG_STR_INPUT_NOT_INTEGER = "Input string is not an integer."
             + "This should be properly handled";
 
@@ -191,10 +191,10 @@ public class UpdateCommand extends Command {
                 GamificationUi.printCelebrateLevelUp();
             }
         } catch (NumberFormatException numberFormatException) {
-            logger.log(Level.INFO, LOG_STR_INPUT_NOT_INTEGER);
+            LOGGER.log(Level.INFO, LOG_STR_INPUT_NOT_INTEGER);
             throw new AtomicHabitException(FEEDBACK_INDEX_NOT_INTEGER_ERROR);
         } catch (IndexOutOfBoundsException e) {
-            logger.log(Level.INFO, LOG_INDEX_OUT_OF_BOUNDS);
+            LOGGER.log(Level.INFO, LOG_INDEX_OUT_OF_BOUNDS);
             throw new AtomicHabitException(FEEDBACK_INDEX_OUT_OF_BOUNDS_ERROR);
         } catch (BadCommandException badCommandException) {
             getTextUi().printErrorFor(badCommandException, NO_ADDITIONAL_MESSAGE);

--- a/src/main/java/wellnus/atomichabit/feature/AtomicHabitList.java
+++ b/src/main/java/wellnus/atomichabit/feature/AtomicHabitList.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
 import wellnus.exception.StorageException;
 import wellnus.exception.TokenizerException;
 import wellnus.storage.AtomicHabitTokenizer;
@@ -18,7 +19,7 @@ public class AtomicHabitList {
     private static final String FILE_NAME = "habit";
     private static final String STORAGE_ERROR = "The file data cannot be stored properly!!";
     private static final String TOKENIZER_ERROR = "The data cannot be tokenized for storage properly!!";
-    private static final Logger LOGGER = Logger.getLogger("AtomicHabitListLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("AtomicHabitListLogger");
     private static final AtomicHabitTokenizer atomicHabitTokenizer = new AtomicHabitTokenizer();
     private ArrayList<AtomicHabit> allAtomicHabits;
 

--- a/src/main/java/wellnus/command/CommandParser.java
+++ b/src/main/java/wellnus/command/CommandParser.java
@@ -40,7 +40,7 @@ public class CommandParser {
     private static final String ERROR_EMPTY_COMMAND = "Command is empty!";
     private static final String ERROR_EMPTY_ARGUMENT = "Command is missing an argument!";
     private static final String ERROR_REPEATED_ARGUMENT = "Command has repeated arguments!";
-    private static final Logger logger = WellNusLogger.getLogger("CommandParserLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("CommandParserLogger");
     private static final String LOG_STR_EMPTY_INPUT = "Input string is empty. This should be properly handled";
     private static final String LOG_EMPTY_ARG = "Argument is empty. This should be properly handled";
 
@@ -79,7 +79,7 @@ public class CommandParser {
         // Perform a string length sanity check
         fullCommandString = fullCommandString.strip();
         if (fullCommandString.length() == 0) {
-            logger.log(Level.INFO, LOG_STR_EMPTY_INPUT);
+            LOGGER.log(Level.INFO, LOG_STR_EMPTY_INPUT);
             throw new BadCommandException(ERROR_EMPTY_COMMAND);
         }
 
@@ -90,14 +90,14 @@ public class CommandParser {
             String currentCommand = rawCommands[i];
             // Case 1 check
             if (currentCommand.startsWith(" ") || currentCommand.length() == 0) {
-                logger.log(Level.INFO, LOG_EMPTY_ARG);
+                LOGGER.log(Level.INFO, LOG_EMPTY_ARG);
                 throw new BadCommandException(ERROR_EMPTY_ARGUMENT);
             }
             // Strip command of whitespace to clean input
             currentCommand = currentCommand.strip();
             // Case 2 check
             if (currentCommand.startsWith(UNPADDED_DELIMITER)) {
-                logger.log(Level.INFO, LOG_EMPTY_ARG);
+                LOGGER.log(Level.INFO, LOG_EMPTY_ARG);
                 throw new BadCommandException(ERROR_EMPTY_COMMAND);
             }
             cleanCommands[i] = currentCommand;
@@ -111,7 +111,7 @@ public class CommandParser {
         String[] words = commandString.split(PAYLOAD_DELIMITER);
         // Bad input checks
         if (words.length == 0) {
-            logger.log(Level.INFO, LOG_STR_EMPTY_INPUT);
+            LOGGER.log(Level.INFO, LOG_STR_EMPTY_INPUT);
             throw new BadCommandException(ERROR_EMPTY_ARGUMENT);
         }
         return words[0].toLowerCase();
@@ -144,7 +144,7 @@ public class CommandParser {
         assert userInput != null : "userInput should not be null";
 
         if (userInput.length() == 0) {
-            logger.log(Level.INFO, LOG_STR_EMPTY_INPUT);
+            LOGGER.log(Level.INFO, LOG_STR_EMPTY_INPUT);
             throw new BadCommandException(ERROR_EMPTY_COMMAND);
         }
         HashMap<String, String> argumentPayload = new HashMap<>();
@@ -177,7 +177,7 @@ public class CommandParser {
 
         userInput = userInput.strip();
         if (userInput.length() == 0) {
-            logger.log(Level.INFO, LOG_STR_EMPTY_INPUT);
+            LOGGER.log(Level.INFO, LOG_STR_EMPTY_INPUT);
             throw new BadCommandException(ERROR_EMPTY_COMMAND);
         }
         String[] parameters = userInput.split(" ");

--- a/src/main/java/wellnus/command/CommandParser.java
+++ b/src/main/java/wellnus/command/CommandParser.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 
 /**
@@ -39,7 +40,7 @@ public class CommandParser {
     private static final String ERROR_EMPTY_COMMAND = "Command is empty!";
     private static final String ERROR_EMPTY_ARGUMENT = "Command is missing an argument!";
     private static final String ERROR_REPEATED_ARGUMENT = "Command has repeated arguments!";
-    private static final Logger logger = Logger.getLogger("CommandParserLogger");
+    private static final Logger logger = WellNusLogger.getLogger("CommandParserLogger");
     private static final String LOG_STR_EMPTY_INPUT = "Input string is empty. This should be properly handled";
     private static final String LOG_EMPTY_ARG = "Argument is empty. This should be properly handled";
 

--- a/src/main/java/wellnus/common/WellNusLogger.java
+++ b/src/main/java/wellnus/common/WellNusLogger.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.logging.FileHandler;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;

--- a/src/main/java/wellnus/common/WellNusLogger.java
+++ b/src/main/java/wellnus/common/WellNusLogger.java
@@ -13,6 +13,11 @@ import java.util.logging.SimpleFormatter;
 import wellnus.exception.StorageException;
 import wellnus.ui.TextUi;
 
+/**
+ * Wrapper class for <code>java.util.logging.Logger</code> that redirects logging
+ * to a specific log file instead of printing it on the user's screen.
+ * @see Logger
+ */
 public class WellNusLogger {
     private static final String CREATE_LOG_FILE_IO_EXCEPTION_MESSAGE = "Failed to create log file.";
     private static final String EXCEPTION_NOTE_MESSAGE = "Logging will not be performed during this app session.";
@@ -61,6 +66,12 @@ public class WellNusLogger {
         }
     }
 
+    /**
+     * Returns an instance of Java's Logger class that directs all logging to a specific
+     * log file instead of the user's screen.
+     * @param loggerName Name of the logger instance to create and return
+     * @return Instance of Logger that logs to a specific file
+     */
     public static Logger getLogger(String loggerName) {
         assert loggerName != null : LOGGER_NAME_NULL_MESSAGE;
         assert !loggerName.isBlank() : LOGGER_NAME_BLANK_MESSAGE;

--- a/src/main/java/wellnus/common/WellNusLogger.java
+++ b/src/main/java/wellnus/common/WellNusLogger.java
@@ -1,0 +1,87 @@
+package wellnus.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.FileHandler;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import wellnus.exception.StorageException;
+import wellnus.ui.TextUi;
+
+public class WellNusLogger {
+    private static final String CREATE_LOG_FILE_IO_EXCEPTION_MESSAGE = "Failed to create log file.";
+    private static final String EXCEPTION_NOTE_MESSAGE = "Logging will not be performed during this app session.";
+    private static final String INVALID_LOG_PATH_MESSAGE = "Invalid log path, cannot create log file.";
+    private static final String LOG_DIR_PATH = "log/";
+    private static final String LOG_FILE_NAME = "wellnus.log";
+    private static final String LOG_PATH_BLANK_MESSAGE = "Blank log path passed to WellNusLogger.checkLogPath().";
+    private static final String LOG_PATH_NULL_MESSAGE = "null log path passed to WellNusLogger.checkLogPath().";
+    private static final String LOGGER_NAME_BLANK_MESSAGE = "Name parameter given to WellNusLogger.getLogger() cannot "
+            + "be blank";
+    private static final String LOGGER_NAME_NULL_MESSAGE = "Name parameter given to WellNusLogger.getLogger() cannot "
+            + "be null";
+    private static final String IO_EXCEPTION_MESSAGE = "Failed to load log file.";
+    private static final int MAX_LOG_FILE_SIZE_MEGA_BYTES = 5;
+    private static final String SECURITY_EXCEPTION_MESSAGE = "Unable to create log file due to security policies.";
+
+    private static void checkLogPath(String logPath) {
+        assert logPath != null : LOG_PATH_NULL_MESSAGE;
+        assert !logPath.isBlank() : LOG_PATH_BLANK_MESSAGE;
+        TextUi textUi = new TextUi();
+        try {
+            File logFile = new File(logPath);
+            Path parentDir = logFile.getParentFile().toPath();
+            Files.createDirectories(parentDir);
+            if (!logFile.exists()) {
+                logFile.createNewFile();
+            } else {
+                int megabyteDivisor = 1024 * 1024;
+                long logFileSizeInMegaBytes = logFile.length() / megabyteDivisor;
+                if (logFileSizeInMegaBytes <= MAX_LOG_FILE_SIZE_MEGA_BYTES) {
+                    return;
+                }
+                // Log file is more than 5 MBs in size, clear it to preserve user's storage space
+                logFile.delete();
+                logFile.createNewFile();
+            }
+        } catch (InvalidPathException invalidPathException) {
+            StorageException storageException = new StorageException(INVALID_LOG_PATH_MESSAGE);
+            textUi.printErrorFor(storageException, EXCEPTION_NOTE_MESSAGE);
+        } catch (IOException ioException) {
+            StorageException storageException = new StorageException(CREATE_LOG_FILE_IO_EXCEPTION_MESSAGE);
+            textUi.printErrorFor(storageException, EXCEPTION_NOTE_MESSAGE);
+        } catch (SecurityException securityException) {
+            StorageException storageException = new StorageException(SECURITY_EXCEPTION_MESSAGE);
+            textUi.printErrorFor(storageException, EXCEPTION_NOTE_MESSAGE);
+        }
+    }
+
+    public static Logger getLogger(String loggerName) {
+        assert loggerName != null : LOGGER_NAME_NULL_MESSAGE;
+        assert !loggerName.isBlank() : LOGGER_NAME_BLANK_MESSAGE;
+        Logger logger = Logger.getLogger(loggerName);
+        FileHandler fileHandler;
+        TextUi textUi = new TextUi();
+        try {
+            String logPath = LOG_DIR_PATH + LOG_FILE_NAME;
+            checkLogPath(logPath);
+            fileHandler = new FileHandler(logPath, true);
+            SimpleFormatter simpleFormatter = new SimpleFormatter();
+            fileHandler.setFormatter(simpleFormatter);
+            logger.addHandler(fileHandler);
+            logger.setUseParentHandlers(false);
+        } catch (SecurityException securityException) {
+            StorageException storageException = new StorageException(SECURITY_EXCEPTION_MESSAGE);
+            textUi.printErrorFor(storageException, EXCEPTION_NOTE_MESSAGE);
+        } catch (IOException ioException) {
+            StorageException storageException = new StorageException(IO_EXCEPTION_MESSAGE);
+            textUi.printErrorFor(storageException, EXCEPTION_NOTE_MESSAGE);
+        }
+        return logger;
+    }
+}

--- a/src/main/java/wellnus/focus/command/ConfigCommand.java
+++ b/src/main/java/wellnus/focus/command/ConfigCommand.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.exception.FocusException;
 import wellnus.exception.WellNusException;
@@ -66,7 +67,7 @@ public class ConfigCommand extends Command {
     private static final String ERROR_TOO_MANY_ARGUMENTS = "Sorry, you seem to have added too many arguments!";
     private static final String ERROR_TOO_FEW_ARGUMENTS = "Sorry, you seem to have not added in any arguments!";
     private static final String ERROR_UNKNOWN_ARGUMENT = "Sorry, I don't seem to understand that argument!";
-    private static final Logger LOGGER = Logger.getLogger("ConfigCommandLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ConfigCommandLogger");
     private static final String LOG_VALIDATION_ASSUMPTION_FAIL = "New cycle/break/work time is assumed to "
             + "have passed the validation bounds and type checking, but has"
             + "unexpectedly failed the second redundant check! This may be a developer error.";

--- a/src/main/java/wellnus/focus/feature/FocusUi.java
+++ b/src/main/java/wellnus/focus/feature/FocusUi.java
@@ -6,6 +6,7 @@ import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
 import wellnus.ui.TextUi;
 
 /**
@@ -14,7 +15,7 @@ import wellnus.ui.TextUi;
  * (10,9,...,1).
  */
 public class FocusUi extends TextUi {
-    private static final Logger LOGGER = Logger.getLogger("FocusUiLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("FocusUiLogger");
     private static final String NO_INPUT_ELEMENT_MSG = "There is no new line of element,"
             + "please key in your input!!";
     private static final String BUFFER_OVERFLOW_MSG = "Your input is too long,"

--- a/src/main/java/wellnus/reflection/command/FavoriteCommand.java
+++ b/src/main/java/wellnus/reflection/command/FavoriteCommand.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.reflection.feature.QuestionList;
 import wellnus.reflection.feature.ReflectUi;
@@ -31,7 +32,7 @@ public class FavoriteCommand extends Command {
     private static final String EMPTY_FAV_LIST = "There is nothing in favorite list, "
             + "please get reflection questions first!!";
     private static final int ARGUMENT_PAYLOAD_SIZE = 1;
-    private static final Logger LOGGER = Logger.getLogger("ReflectFavCommandLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectFavCommandLogger");
     private static final ReflectUi UI = new ReflectUi();
     private QuestionList questionList;
 

--- a/src/main/java/wellnus/reflection/command/GetCommand.java
+++ b/src/main/java/wellnus/reflection/command/GetCommand.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.exception.StorageException;
 import wellnus.reflection.feature.QuestionList;
@@ -21,7 +22,7 @@ public class GetCommand extends Command {
     public static final String COMMAND_DESCRIPTION = "get - Get a list of questions to reflect on.";
     public static final String COMMAND_USAGE = "usage: get";
     public static final String COMMAND_KEYWORD = "get";
-    private static final Logger LOGGER = Logger.getLogger("ReflectGetCommandLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectGetCommandLogger");
     private static final String FEATURE_NAME = "reflect";
 
     private static final String PAYLOAD = "";

--- a/src/main/java/wellnus/reflection/command/HomeCommand.java
+++ b/src/main/java/wellnus/reflection/command/HomeCommand.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.reflection.feature.QuestionList;
 import wellnus.reflection.feature.ReflectUi;
@@ -18,7 +19,7 @@ public class HomeCommand extends Command {
     public static final String COMMAND_DESCRIPTION = "home - Return back to the main menu of WellNUS++.";
     public static final String COMMAND_USAGE = "usage: home";
     public static final String COMMAND_KEYWORD = "home";
-    private static final Logger LOGGER = Logger.getLogger("ReflectHomeCommandLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectHomeCommandLogger");
     private static final String FEATURE_NAME = "reflect";
     private static final String PAYLOAD = "";
     private static final String INVALID_COMMAND_MSG = "Command is invalid.";

--- a/src/main/java/wellnus/reflection/command/LikeCommand.java
+++ b/src/main/java/wellnus/reflection/command/LikeCommand.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.exception.StorageException;
 import wellnus.exception.TokenizerException;
@@ -35,7 +36,7 @@ public class LikeCommand extends Command {
     private static final int ARGUMENT_PAYLOAD_SIZE = 1;
     private static final int UPPER_BOUND = 5;
     private static final int LOWER_BOUND = 1;
-    private static final Logger LOGGER = Logger.getLogger("ReflectLikeCommandLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectLikeCommandLogger");
     private static final ReflectUi UI = new ReflectUi();
     private Set<Integer> randomQuestionIndexes;
     private QuestionList questionList;

--- a/src/main/java/wellnus/reflection/command/PrevCommand.java
+++ b/src/main/java/wellnus/reflection/command/PrevCommand.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.reflection.feature.QuestionList;
 import wellnus.reflection.feature.ReflectUi;
@@ -29,7 +30,7 @@ public class PrevCommand extends Command {
             + "Your data file might be corrupted!!";
     private static final String PAYLOAD = "";
     private static final int ARGUMENT_PAYLOAD_SIZE = 1;
-    private static final Logger LOGGER = Logger.getLogger("ReflectPrevCommandLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectPrevCommandLogger");
     private static final ReflectUi UI = new ReflectUi();
     private QuestionList questionList;
 

--- a/src/main/java/wellnus/reflection/command/UnlikeCommand.java
+++ b/src/main/java/wellnus/reflection/command/UnlikeCommand.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import wellnus.command.Command;
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.exception.ReflectionException;
 import wellnus.exception.StorageException;
@@ -38,7 +39,7 @@ public class UnlikeCommand extends Command {
     private static final int ARGUMENT_PAYLOAD_SIZE = 1;
     private static final int LOWER_BOUND = 1;
     private static final int EMPTY_LIST = 0;
-    private static final Logger LOGGER = Logger.getLogger("ReflectUnlikeCommandLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectUnlikeCommandLogger");
     private static final ReflectUi UI = new ReflectUi();
     private Set<Integer> favQuestionIndexes;
     private QuestionList questionList;

--- a/src/main/java/wellnus/reflection/feature/QuestionList.java
+++ b/src/main/java/wellnus/reflection/feature/QuestionList.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
 import wellnus.exception.StorageException;
 import wellnus.exception.TokenizerException;
 import wellnus.storage.ReflectionTokenizer;
@@ -56,7 +57,7 @@ public class QuestionList {
     private static final String FILE_NAME = "reflect";
     private static final RandomNumberGenerator RANDOM_NUMBER_GENERATOR =
             new RandomNumberGenerator(RANDOM_NUMBER_UPPERBOUND);
-    private static final Logger LOGGER = Logger.getLogger("ReflectQuestionListLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectQuestionListLogger");
     private static final ReflectionTokenizer reflectionTokenizer = new ReflectionTokenizer();
     private static final ReflectUi UI = new ReflectUi();
     private static final boolean HAS_RANDOM_QUESTIONS = true;

--- a/src/main/java/wellnus/reflection/feature/ReflectionManager.java
+++ b/src/main/java/wellnus/reflection/feature/ReflectionManager.java
@@ -5,6 +5,7 @@ import java.util.NoSuchElementException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
 import wellnus.exception.BadCommandException;
 import wellnus.manager.Manager;
 import wellnus.reflection.command.FavoriteCommand;
@@ -23,7 +24,7 @@ public class ReflectionManager extends Manager {
     public static final String FEATURE_HELP_DESCRIPTION = "Reflection (reflect) - Take some time to pause and reflect "
             + "with our specially curated list of questions and reflection management tools.";
     public static final String FEATURE_NAME = "reflect";
-    private static final Logger LOGGER = Logger.getLogger("ReflectionManagerLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectionManagerLogger");
     private static final String GET_COMMAND = "get";
     private static final String HOME_COMMAND = "home";
     private static final String HELP_COMMAND = "help";

--- a/src/main/java/wellnus/storage/ReflectionTokenizer.java
+++ b/src/main/java/wellnus/storage/ReflectionTokenizer.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
 import wellnus.exception.TokenizerException;
 
 /**
@@ -26,7 +27,7 @@ public class ReflectionTokenizer implements Tokenizer<Set<Integer>> {
     private static final int NO_LIMIT = -1;
     private static final String DETOKENIZE_ERROR_MESSAGE = "Detokenization failed! "
             + "The file might be corrupted";
-    private static final Logger LOGGER = Logger.getLogger("ReflectTokenizerLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("ReflectTokenizerLogger");
     private String getTokenizedIndexes(String key, Set<Integer> indexesToTokenize) {
         String tokenizedIndexes = key + COLON_CHARACTER;
         for (int index : indexesToTokenize) {

--- a/src/main/java/wellnus/storage/Storage.java
+++ b/src/main/java/wellnus/storage/Storage.java
@@ -14,6 +14,7 @@ import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
 import wellnus.exception.StorageException;
 
 /**
@@ -58,7 +59,7 @@ public class Storage {
     private static final String ASSERT_LIST_NOT_NULL = "list input should not be null!";
     private static final String ASSERT_STRING_NOT_NULL = "string input should not be null!";
     private static final String ASSERT_FILE_NOT_NULL = "file input should not be null!";
-    private static final Logger LOGGER = Logger.getLogger("StorageLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("StorageLogger");
     private static final String LOG_ACCESS_ERROR = "WellNUS++ has encountered a severe input/output error! \n"
             + "Check if file permissions and data directory are properly instantiated?";
     private static final String LOG_MISSING_FILE = "WellNUS++ could not find a file.\n"

--- a/src/main/java/wellnus/ui/TextUi.java
+++ b/src/main/java/wellnus/ui/TextUi.java
@@ -7,6 +7,8 @@ import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import wellnus.common.WellNusLogger;
+
 /**
  * TextUi class for reading user inputs and printing outputs.<br/>
  * <br/>
@@ -14,7 +16,7 @@ import java.util.logging.Logger;
  * This is to accommodate to the uniqueness of each feature.
  */
 public class TextUi {
-    private static final Logger LOGGER = Logger.getLogger("TextUiLogger");
+    private static final Logger LOGGER = WellNusLogger.getLogger("TextUiLogger");
     private static final String ALERT_SEPARATOR = "!!!!!!-------!!!!!--------!!!!!!!------!!!!!"
             + "---------!!!!!!!";
     private static final String INDENTATION_SPACES = "    ";


### PR DESCRIPTION
Since logging currently prints directly to the user's screen, which is unsightly, let's redirect all logging in our app to a specific log file, `log/wellnus.log` relative to the runtime jar file.
Some basic features of this implementation:
-Entire app's logging will be saved inside this file, `log/wellnus.log`
-To preserve user's storage space, `log/wellnus.log` will be cleared on the next app run if it exceeds **5MB**

This closes #111 #257.