### PR TITLE
Improve `gamif` `stats` command validation

### DIFF
--- a/src/main/java/wellnus/gamification/command/StatsCommand.java
+++ b/src/main/java/wellnus/gamification/command/StatsCommand.java
@@ -17,6 +17,8 @@ public class StatsCommand extends Command {
     public static final String COMMAND_KEYWORD = "stats";
     public static final String COMMAND_USAGE = "usage: stats";
     public static final String FEATURE_NAME = "gamif";
+    private static final String EXTRA_ARGUMENTS_MESSAGE = "'%s' doesn't take in additional arguments, drop the '%s' "
+            + "and try again.";
     private static final int NUM_OF_ARGUMENTS = 1;
     private static final String WRONG_ARGUMENTS_MESSAGE = "Invalid arguments given to 'stats'!";
     private static final String WRONG_COMMAND_MESSAGE = "Invalid command issued, expected 'stats'!";
@@ -74,6 +76,10 @@ public class StatsCommand extends Command {
         assert arguments.containsKey(getCommandKeyword()) : WRONG_COMMAND_MESSAGE;
         if (arguments.size() > NUM_OF_ARGUMENTS) {
             throw new BadCommandException(WRONG_ARGUMENTS_MESSAGE);
+        }
+        String payload = arguments.get(getCommandKeyword());
+        if (!payload.isBlank()) {
+            throw new BadCommandException(String.format(EXTRA_ARGUMENTS_MESSAGE, getCommandKeyword(), payload));
         }
     }
 


### PR DESCRIPTION
Implement additional checks to ensure that extra arguments are not given to the `stats` command.
This catches bogus commands like `stats test` which now correctly throws a `BadCommandException`.

This fixes #279.