### PR TITLE
Fix AboutUs Page PPP URLs

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -1,9 +1,9 @@
 # About us
 
-| Display                                       |           Name             |            Github Profile                  |             Portfolio              |
-|-----------------------------------------------|:--------------------------:|:-------------------------------------:     |:----------------------------------:|
-| ![Chen Wenxin](./team/wenxin.jpg)             |        Chen Wenxin         | [Github](https://github.com/wenxin-c)      | [Portfolio](docs/team/wenxin-c.md) |
-| ![Wang Haoyang](./team/haoyangw.png)          |        Wang Haoyang        | [Github](https://github.com/haoyangw)      | [Portfolio](docs/team/haoyangw.md) |
-| ![Wang Yongbin](./team/yongbin.png)           |        Wang Yongbin        | [Github](https://github.com/YongbinWang)   | [Portfolio](docs/team/yongbin.md)  |
-| ![Bernard Lesley](./team/bernard.jpg)         |   Bernard Lesley Efendy    | [Github](https://github.com/BernardLesley) | [Portfolio](docs/team/bernard.md)  |
-| ![Yek Jin Teck, Nicholas](./team/nichyjt.jpg) |   Yek Jin Teck, Nicholas   |  [Github](https://github.com/nichyjt)      | [Portfolio](docs/team/nichyjt.md)  |
+| Display                                       |           Name             |            Github Profile                  |                                    Portfolio                                    |
+|-----------------------------------------------|:--------------------------:|:-------------------------------------:     |:-------------------------------------------------------------------------------:|
+| ![Chen Wenxin](./team/wenxin.jpg)             |        Chen Wenxin         | [Github](https://github.com/wenxin-c)      |   [Portfolio](https://ay2223s2-cs2113-t12-4.github.io/tp/team/wenxin-c.html)    |
+| ![Wang Haoyang](./team/haoyangw.png)          |        Wang Haoyang        | [Github](https://github.com/haoyangw)      |   [Portfolio](https://ay2223s2-cs2113-t12-4.github.io/tp/team/haoyangw.html)    |
+| ![Wang Yongbin](./team/yongbin.png)           |        Wang Yongbin        | [Github](https://github.com/YongbinWang)   |  [Portfolio](https://ay2223s2-cs2113-t12-4.github.io/tp/team/yongbinwang.html)  |
+| ![Bernard Lesley](./team/bernard.jpg)         |   Bernard Lesley Efendy    | [Github](https://github.com/BernardLesley) | [Portfolio](https://ay2223s2-cs2113-t12-4.github.io/tp/team/bernardlesley.html) |
+| ![Yek Jin Teck, Nicholas](./team/nichyjt.jpg) |   Yek Jin Teck, Nicholas   |  [Github](https://github.com/nichyjt)      |    [Portfolio](https://ay2223s2-cs2113-t12-4.github.io/tp/team/nichyjt.html)    |


### PR DESCRIPTION
AboutUs Page currently points to a non-existent markdown page. Github pages actually generates a html file for each markdown in the docs folder, so switch to that URL instead.

Check that your PPPs fit within the page limit everyone!

This addresses #327.