### PR TITLE
Reflect error message and help command format bug fix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -132,13 +132,13 @@ Expected outcome:
 ------------------------------------------------------------
     WellNUS++ is a Command Line Interface (CLI) app for you to keep track, manage and improve your physical and mental wellness.
     Input `help` to see all available commands.
-Input `help [command-to-check]` to get usage help for a specific command.
-Here are all the commands available for you!
+    Input `help [command-to-check]` to get usage help for a specific command.
+    Here are all the commands available for you!
     
-    1. hb(Atomic Habits) - Track and manage your habits with our suite of tools to help you grow and nurture a better you!
-    2. reflect(Self Reflection) - Take some time to pause and reflect with our specially curated list of questions and reflection management tools.
-    3. ft(Focus Timer) - Set a configurable 'Pomodoro' timer with work and rest cycles to keep yourself focused and productive!
-    4. gamif(Gamification) - Gamification gives you the motivation to continue improving your wellness by rewarding you for your efforts!
+    1. hb - Atomic Habits - Track and manage your habits with our suite of tools to help you grow and nurture a better you!
+    2. reflect - Self Reflection - Take some time to pause and reflect with our specially curated list of questions and reflection management tools.
+    3. ft - Focus Timer - Set a configurable 'Pomodoro' timer with work and rest cycles to keep yourself focused and productive!
+    4. gamif - Gamification - Gamification gives you the motivation to continue improving your wellness by rewarding you for your efforts!
     5. exit - Close WellNUS++ and return to your terminal.
     6. help - Get help on what commands can be used in WellNUS++.
 ------------------------------------------------------------
@@ -152,7 +152,7 @@ Expected outcome:
 
 ```
 ------------------------------------------------------------
-    hb(Atomic Habits) - Track and manage your habits with our suite of tools to help you grow and nurture a better you!
+    hb - Atomic Habits - Track and manage your habits with our suite of tools to help you grow and nurture a better you!
     usage: hb
 ------------------------------------------------------------
 ```
@@ -385,18 +385,19 @@ Example of usage 1:
 Expected outcome:
 
 ```
-------------------------------------------------------------
-    Atomic Habits (hb) - Track and manage your habits with our suite of tools to help you grow and nurture a better you!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    hb - Atomic Habits - Track and manage your habits with our suite of tools to help you grow and nurture a better you!
     Input `help` to see all available commands.
-Input `help [command-to-check] to get usage help for a specific command.
-Here are all the commands available for you!
+    Input `help [command-to-check] to get usage help for a specific command.
+    Here are all the commands available for you!
     
     1. add - Add a habit to your habit tracker.
-    2. help - Get help on what commands can be used in Atomic Habit WellNUS++
-    3. home - Return back to the main menu of WellNUS++.
-    4. list - Lists out all the habits in your tracker.
-    5. update - Update how many times you've done a habit.
-------------------------------------------------------------
+    2. delete - Delete the habit you don't want to continue.
+    3. help - Get help on what commands can be used in Atomic Habit WellNUS++
+    4. home - Return back to the main menu of WellNUS++.
+    5. list - Lists out all the habits in your tracker.
+    6. update - Update how many times you've done a habit.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 Example of usage 2:
@@ -406,10 +407,10 @@ Example of usage 2:
 Expected outcome:
 
 ```
-------------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     add - Add a habit to your habit tracker.
     usage: add --name (your habit name)
-------------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 <!-- @@author haoyangw -->
@@ -478,16 +479,16 @@ Example of usage 1:
 Expected outcome:
 
 ```
-------------------------------------------------------------
-    Gamification (gamif) - Gamification gives you the motivation to continue improving your wellness by rewarding you for your efforts!
+######################################################################
+    gamif - Gamification - Gamification gives you the motivation to continue improving your wellness by rewarding you for your efforts!
     Input `help` to see all available commands.
-Input `help [command-to-check]` to get usage help for a specific command.
-Here are all the commands available for you!
+    Input `help [command-to-check]` to get usage help for a specific command.
+    Here are all the commands available for you!
     
     1. help - Get help on what commands can be used in WellNUS++ Gamification Feature
     2. home - Returns the user to the main WellNus++ session
     3. stats - Displays the user's XP level and points
-------------------------------------------------------------
+######################################################################
 ```
 
 Example of usage 2:
@@ -497,10 +498,10 @@ Example of usage 2:
 Expected outcome:
 
 ```
-------------------------------------------------------------
+######################################################################
     stats - Displays the user's XP level and points
     usage: stats
-------------------------------------------------------------
+######################################################################
 ```
 
 <!-- @@author wenxin-c -->
@@ -685,10 +686,10 @@ Expected outcome:
 
 ```
 ============================================================
-    reflect(Self Reflection) - Take some time to pause and reflect with our specially curated list of questions and reflection management tools.
+    reflect - Self Reflection - Take some time to pause and reflect with our specially curated list of questions and reflection management tools.
     Input `help` to see all available commands.
-Input `help [command-to-check] to get usage help for a specific command.
-Here are all the commands available for you!
+    Input `help [command-to-check] to get usage help for a specific command.
+    Here are all the commands available for you!
     
     1. fav - Get the list of questions that have been added to the favorite list.
     2. get - Get a list of questions to reflect on.
@@ -891,30 +892,29 @@ Expected outcome:
 
 ```
 ************************************************************
-    Focus Timer (ft) - Set a configurable timer with work and rest cycles to keep yourself focused and productive!
+    ft - Focus Timer - Set a configurable 'Pomodoro' timer with work and rest cycles to keep yourself focused and productive!
     Input `help` to see all available commands.
-Input `help [command-to-check]` to get usage help for a specific command.
-Here are all the commands available for you!
+    Input `help [command-to-check]` to get usage help for a specific command.
+    Here are all the commands available for you!
     
     1. check - Check the time left in the current session.
-This can only be used when a countdown is underway!
+    This can only be used when a countdown is underway!
     2. config - Change the number of cycles and the times of the work, break and long break of your session!
-Note that the minimum cycles is 2,
-the maximum number of cycles is 5,
-the maximum work/break times is 60 minutes,
-the minimum work/break times is 1 minute.
-This is to ensure your well-being, as higher values might be counter-productive!
+    Note that the minimum cycles is 2,
+    the maximum number of cycles is 5,
+    the maximum work/break times is 60 minutes,
+    the minimum work/break times is 1 minute.
+    This is to ensure your well-being, as higher values might be counter-productive!
     3. help - Get help on what commands can be used in Focus Timer WellNUS++
     4. home - Stop the session and go back to WellNUS++.
     5. next - When a timer ends, move on to the next countdown!
-This can only be used when a countdown timer has ended!
+    This can only be used when a countdown timer has ended!
     6. pause - Pause the session!Can only be used when a countdown is ticking.
     7. resume - Continue the countdown.
-Can only be used when a countdown is paused.
+    Can only be used when a countdown is paused.
     8. start - Start your focus session!
     9. stop - Stop the session. You will have to `start` your focus session again!
 ************************************************************
-
 ```
 
 Example of usage 2:

--- a/src/main/java/wellnus/atomichabit/command/DeleteCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/DeleteCommand.java
@@ -29,8 +29,9 @@ public class DeleteCommand extends Command {
     private static final String COMMAND_INVALID_PAYLOAD = "Invalid payload given to 'delete'!";
     private static final String FEEDBACK_STRING = "The following habit has been deleted:";
     private static final String FEEDBACK_STRING_TWO = "has been successfully deleted";
-    private static final String FEEDBACK_INDEX_NOT_INTEGER_ERROR = "Invalid index payload given, expected an integer";
-    private static final String FEEDBACK_INDEX_OUT_OF_BOUNDS_ERROR = "Invalid index payload given, "
+    private static final String FEEDBACK_INDEX_NOT_INTEGER_ERROR = "Invalid index payload given in 'delete', expected "
+            + "a valid integer";
+    private static final String FEEDBACK_INDEX_OUT_OF_BOUNDS_ERROR = "Invalid index payload given in 'delete', "
             + "index is out of range!";
     private static final int INDEX_OFFSET = 1;
     private static final String LINE_SEPARATOR = System.lineSeparator();

--- a/src/main/java/wellnus/atomichabit/command/HelpCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/HelpCommand.java
@@ -21,8 +21,9 @@ public class HelpCommand extends Command {
     private static final String BAD_ARGUMENTS_MESSAGE = "Invalid arguments given to 'help'!";
     private static final String COMMAND_KEYWORD = "help";
     private static final String NO_FEATURE_KEYWORD = "";
-    private static final String HELP_PREAMBLE = "Input `help` to see all available commands.\n"
-            + "Input `help [command-to-check] to get usage help for a specific command.\n"
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final String HELP_PREAMBLE = "Input `help` to see all available commands." + LINE_SEPARATOR
+            + "Input `help [command-to-check] to get usage help for a specific command." + LINE_SEPARATOR
             + "Here are all the commands available for you!";
     private static final String COMMAND_INVALID_PAYLOAD = "Invalid payload given to 'help'!";
     private static final String COMMAND_INVALID_COMMAND_NOTE = "help command " + COMMAND_USAGE;

--- a/src/main/java/wellnus/atomichabit/command/ListCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/ListCommand.java
@@ -18,7 +18,8 @@ public class ListCommand extends Command {
     public static final String COMMAND_USAGE = "usage: list";
     public static final String COMMAND_KEYWORD = "list";
     private static final int COMMAND_NUM_OF_ARGUMENTS = 1;
-    private static final String COMMAND_INVALID_ARGUMENTS_MESSAGE = "Invalid command issued, expected 'list'!";
+    private static final String COMMAND_INVALID_COMMAND_MESSAGE = "Invalid command issued, expected 'list'!";
+    private static final String COMMAND_INVALID_ARGUMENTS_MESSAGE = "Invalid arguments given to 'list'!";
     private static final String COMMAND_INVALID_PAYLOAD = "Invalid payload given to 'list'!";
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final String FIRST_STRING = "Here is the current accumulation of your atomic habits!"
@@ -112,7 +113,7 @@ public class ListCommand extends Command {
             throw new BadCommandException(ListCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
         }
         if (!arguments.containsKey(ListCommand.COMMAND_KEYWORD)) {
-            throw new BadCommandException(ListCommand.COMMAND_INVALID_ARGUMENTS_MESSAGE);
+            throw new BadCommandException(ListCommand.COMMAND_INVALID_COMMAND_MESSAGE);
         }
         if (arguments.get(COMMAND_KEYWORD) != "") {
             throw new BadCommandException(ListCommand.COMMAND_INVALID_PAYLOAD);

--- a/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
@@ -33,22 +33,24 @@ public class UpdateCommand extends Command {
     private static final String COMMAND_INVALID_COMMAND_NOTE = "update command " + COMMAND_USAGE;
     private static final String COMMAND_INVALID_ARGUMENT_MESSAGE = "Invalid arguments given to 'update'!";
     private static final String COMMAND_INVALID_PAYLOAD = "Invalid payload given to 'update'!";
-    private static final String COMMAND_INVALID_PAYLOAD_INCREMENT = "Invalid payload given to 'by' argument!";
+    private static final String COMMAND_INVALID_PAYLOAD_INCREMENT = "Invalid payload given in 'update' "
+            + "command!";
     private static final String DOT = ".";
     private static final int DEFAULT_INCREMENT = 1;
     private static final int ZERO = 0;
     private static final String FEEDBACK_STRING = "The following habit has been incremented! Keep up the good work!";
-    private static final String FEEDBACK_INDEX_NOT_INTEGER_ERROR = "Invalid index payload given, expected an integer!";
-    private static final String FEEDBACK_INDEX_OUT_OF_BOUNDS_ERROR = "Invalid index payload given, "
+    private static final String FEEDBACK_INDEX_NOT_INTEGER_ERROR = "Invalid payload given in 'update' command, "
+            + "expected a valid integer!";
+    private static final String FEEDBACK_INDEX_OUT_OF_BOUNDS_ERROR = "Invalid payload given in 'update' command, "
             + "index is out of range!";
-    private static final String FEEDBACK_DECREMENT_ERROR = "Invalid decrement payload given, "
+    private static final String FEEDBACK_DECREMENT_ERROR = "Invalid decrement payload given in 'update' command, "
             + "decrement value is out of range!";
     private static final int INDEX_OFFSET = 1;
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final int MINIMUM_INCREMENT = 1;
     private static final String UPDATE_INVALID_ARGUMENTS_MESSAGE = "Invalid arguments given to 'update'!";
-    private static final String UPDATE_INVALID_INCREMENT_COUNT = "Invalid increment payload given, increment with "
-            + "minimum of 1 is expected!";
+    private static final String UPDATE_INVALID_INCREMENT_COUNT = "Invalid increment payload given in 'update' command, "
+            + "increment with minimum of 1 is expected!";
     private static final String STORE_GAMIF_DATA_FAILED_NOTE_MESSAGE = "Error saving to storage!";
     private static final String REGEX_INTEGER_ONLY_PATTERN = "\\s*-?\\d+\\s*";
     private static final Logger LOGGER = WellNusLogger.getLogger("UpdateAtomicHabitLogger");
@@ -56,7 +58,6 @@ public class UpdateCommand extends Command {
             + "This should be properly handled";
     private static final String LOG_INDEX_OUT_OF_BOUNDS = "Input index is out of bounds."
             + "This should be properly handled";
-    private static final String NO_ADDITIONAL_MESSAGE = "";
     private static final int NUM_OF_XP_PER_INCREMENT = 1;
     private final AtomicHabitList atomicHabits;
     private final GamificationData gamificationData;

--- a/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
+++ b/src/main/java/wellnus/atomichabit/command/UpdateCommand.java
@@ -46,7 +46,7 @@ public class UpdateCommand extends Command {
     private static final int INDEX_OFFSET = 1;
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final int MINIMUM_INCREMENT = 1;
-    private static final String UPDATE_INVALID_ARGUMENTS_MESSAGE = "Invalid arguments given to 'update'";
+    private static final String UPDATE_INVALID_ARGUMENTS_MESSAGE = "Invalid arguments given to 'update'!";
     private static final String UPDATE_INVALID_INCREMENT_COUNT = "Invalid increment payload given, increment with "
             + "minimum of 1 is expected!";
     private static final String STORE_GAMIF_DATA_FAILED_NOTE_MESSAGE = "Error saving to storage!";

--- a/src/main/java/wellnus/atomichabit/feature/AtomicHabitManager.java
+++ b/src/main/java/wellnus/atomichabit/feature/AtomicHabitManager.java
@@ -52,8 +52,10 @@ public class AtomicHabitManager extends Manager {
                     + "update command " + UpdateCommand.COMMAND_USAGE + LINE_SEPARATOR
                     + "help command " + HelpCommand.COMMAND_USAGE + LINE_SEPARATOR
                     + "home command " + HomeCommand.COMMAND_USAGE;
-    private static final String FEEDBACK_INDEX_EXCEPTION_NOTE = "Please input an appropriate integer for the "
-            + "arguments!";
+    private static final String ADD_USAGE = "add command " + AddCommand.COMMAND_USAGE;
+    private static final String DELETE_USAGE = "delete command " + DeleteCommand.COMMAND_USAGE;
+    private static final String HOME_USAGE = "home command " + HomeCommand.COMMAND_USAGE;
+    private static final String UPDATE_USAGE = "update command " + UpdateCommand.COMMAND_USAGE;
     private final AtomicHabitUi atomicHabitUi;
     private final AtomicHabitList habitList;
     private final GamificationData gamificationData;
@@ -133,9 +135,31 @@ public class AtomicHabitManager extends Manager {
                 }
                 isExit = HomeCommand.isExit(command);
             } catch (BadCommandException badCommandException) {
-                getTextUi().printErrorFor(badCommandException, COMMAND_INVALID_COMMAND_NOTE);
+                String errorMessage = badCommandException.getMessage();
+                if (errorMessage.contains(ADD_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(badCommandException, ADD_USAGE);
+                } else if (errorMessage.contains(DELETE_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(badCommandException, DELETE_USAGE);
+                } else if (errorMessage.contains(HOME_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(badCommandException, HOME_USAGE);
+                } else if (errorMessage.contains(UPDATE_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(badCommandException, UPDATE_USAGE);
+                } else {
+                    getTextUi().printErrorFor(badCommandException, COMMAND_INVALID_COMMAND_NOTE);
+                }
             } catch (WellNusException exception) {
-                getTextUi().printErrorFor(exception, FEEDBACK_INDEX_EXCEPTION_NOTE);
+                String errorMessage = exception.getMessage();
+                if (errorMessage.contains(ADD_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(exception, ADD_USAGE);
+                } else if (errorMessage.contains(DELETE_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(exception, DELETE_USAGE);
+                } else if (errorMessage.contains(HOME_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(exception, HOME_USAGE);
+                } else if (errorMessage.contains(UPDATE_COMMAND_KEYWORD)) {
+                    getTextUi().printErrorFor(exception, UPDATE_USAGE);
+                } else {
+                    getTextUi().printErrorFor(exception, COMMAND_INVALID_COMMAND_NOTE);
+                }
             }
         }
     }

--- a/src/main/java/wellnus/atomichabit/feature/AtomicHabitManager.java
+++ b/src/main/java/wellnus/atomichabit/feature/AtomicHabitManager.java
@@ -22,7 +22,7 @@ import wellnus.manager.Manager;
  * This class will handle calling the different available commands for Atomic Habits according to user input
  */
 public class AtomicHabitManager extends Manager {
-    public static final String FEATURE_HELP_DESCRIPTION = "hb(Atomic Habits) - Track and manage your habits "
+    public static final String FEATURE_HELP_DESCRIPTION = "hb - Atomic Habits - Track and manage your habits "
             + "with our suite of tools to help you grow and nurture a better you!";
     public static final String FEATURE_NAME = "hb";
     private static final String ADD_COMMAND_KEYWORD = "add";

--- a/src/main/java/wellnus/command/HelpCommand.java
+++ b/src/main/java/wellnus/command/HelpCommand.java
@@ -24,8 +24,9 @@ public class HelpCommand extends Command {
     private static final String COMMAND_INVALID_PAYLOAD = "Invalid payload given to 'help'!";
     private static final String COMMAND_INVALID_COMMAND_NOTE = "help command " + COMMAND_USAGE;
     private static final String NO_FEATURE_KEYWORD = "";
-    private static final String HELP_PREAMBLE = "Input `help` to see all available commands.\n"
-            + "Input `help [command-to-check]` to get usage help for a specific command.\n"
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final String HELP_PREAMBLE = "Input `help` to see all available commands." + LINE_SEPARATOR
+            + "Input `help [command-to-check]` to get usage help for a specific command." + LINE_SEPARATOR
             + "Here are all the commands available for you!";
     private static final String USAGE_HABIT = "\tusage: hb";
     private static final String USAGE_REFLECT = "\tusage: reflect";

--- a/src/main/java/wellnus/focus/command/CheckCommand.java
+++ b/src/main/java/wellnus/focus/command/CheckCommand.java
@@ -12,8 +12,9 @@ import wellnus.focus.feature.Session;
  * Represents a command to check the time left in the current session.
  */
 public class CheckCommand extends Command {
-    public static final String COMMAND_DESCRIPTION = "check - Check the time left in the current session.\n"
-            + "This can only be used when a countdown is underway!";
+
+    public static final String COMMAND_DESCRIPTION = "check - Check the time left in the current session."
+            + System.lineSeparator() + "This can only be used when a countdown is underway!";
     public static final String COMMAND_USAGE = "usage: check";
     public static final String COMMAND_KEYWORD = "check";
     private static final int COMMAND_NUM_OF_ARGUMENTS = 1;

--- a/src/main/java/wellnus/focus/command/ConfigCommand.java
+++ b/src/main/java/wellnus/focus/command/ConfigCommand.java
@@ -58,15 +58,15 @@ public class ConfigCommand extends Command {
     private static final int MIN_CYCLES = 2;
     // Message constants
     private static final String ASSERT_STRING_INPUT_NOT_NULL = "String input should not be null!";
-    private static final String ERROR_NOT_A_NUMBER = "Invalid integer payload given!";
-    private static final String ERROR_LARGE_CYCLES = "Invalid cycle payload given, the max cycles you can set is "
-            + MAX_CYCLES;
-    private static final String ERROR_LESS_EQUAL_MIN_CYCLES = "Invalid cycle payload given, the min cycles you can set "
-            + "is " + MIN_CYCLES;
-    private static final String ERROR_LARGE_MINUTES = "Invalid minutes payload given, the max time you can set is "
-            + MAX_MINUTES;
-    private static final String ERROR_LESS_EQUAL_MIN_MINUTES = "Invalid minutes payload given, the min time you can "
-            + "set is " + MIN_MINUTES;
+    private static final String ERROR_NOT_A_NUMBER = "Invalid payload given in 'config', expected a valid integer!";
+    private static final String ERROR_LARGE_CYCLES = "Invalid cycle payload given in 'config', the max cycles you "
+            + "can set is " + MAX_CYCLES + "!";
+    private static final String ERROR_LESS_EQUAL_MIN_CYCLES = "Invalid cycle payload given in 'config', the min "
+            + "cycles you can set is " + MIN_CYCLES + "!";
+    private static final String ERROR_LARGE_MINUTES = "Invalid minutes payload given in 'config', the max time "
+            + "you can set is " + MAX_MINUTES + "!";
+    private static final String ERROR_LESS_EQUAL_MIN_MINUTES = "Invalid minutes payload given in 'config', the min "
+            + "time you can set is " + MIN_MINUTES + "!";
     private static final String COMMAND_INVALID_ARGUMENTS = "Invalid arguments given to 'config'!";
     private static final String ASSERT_MISSING_KEYWORD = "Missing command keyword";
     private static final Logger LOGGER = WellNusLogger.getLogger("ConfigCommandLogger");

--- a/src/main/java/wellnus/focus/command/ConfigCommand.java
+++ b/src/main/java/wellnus/focus/command/ConfigCommand.java
@@ -50,13 +50,13 @@ public class ConfigCommand extends Command {
     // Message constants
     private static final String ASSERT_STRING_INPUT_NOT_NULL = "String input should not be null!";
     private static final String ERROR_NOT_A_NUMBER = "Invalid payload given in 'config', expected a valid integer!";
-    private static final String ERROR_LARGE_CYCLES = "Invalid cycle payload given in 'config', the max cycles you "
+    private static final String ERROR_LARGE_CYCLES = "Invalid cycle payload given in 'config', the maximum cycles you "
             + "can set is " + MAX_CYCLES + "!";
-    private static final String ERROR_LESS_EQUAL_MIN_CYCLES = "Invalid cycle payload given in 'config', the min "
+    private static final String ERROR_LESS_EQUAL_MIN_CYCLES = "Invalid cycle payload given in 'config', the minimum "
             + "cycles you can set is " + MIN_CYCLES + "!";
-    private static final String ERROR_LARGE_MINUTES = "Invalid minutes payload given in 'config', the max time "
+    private static final String ERROR_LARGE_MINUTES = "Invalid minutes payload given in 'config', the maximum time "
             + "you can set is " + MAX_MINUTES + "!";
-    private static final String ERROR_LESS_EQUAL_MIN_MINUTES = "Invalid minutes payload given in 'config', the min "
+    private static final String ERROR_LESS_EQUAL_MIN_MINUTES = "Invalid minutes payload given in 'config', the minimum "
             + "time you can set is " + MIN_MINUTES + "!";
     private static final String ERROR_LONGBREAK_LARGER = "Invalid new 'config'! Your break time, %s min "
             + "should be greater or equal to your "

--- a/src/main/java/wellnus/focus/command/HelpCommand.java
+++ b/src/main/java/wellnus/focus/command/HelpCommand.java
@@ -22,8 +22,9 @@ public class HelpCommand extends Command {
     private static final String COMMAND_INVALID_COMMAND_NOTE = "help command " + COMMAND_USAGE;
     private static final String COMMAND_KEYWORD = "help";
     private static final String NO_FEATURE_KEYWORD = "";
-    private static final String HELP_PREAMBLE = "Input `help` to see all available commands.\n"
-            + "Input `help [command-to-check]` to get usage help for a specific command.\n"
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final String HELP_PREAMBLE = "Input `help` to see all available commands." + LINE_SEPARATOR
+            + "Input `help [command-to-check]` to get usage help for a specific command." + LINE_SEPARATOR
             + "Here are all the commands available for you!";
     private static final String ERROR_UNKNOWN_COMMAND = "Invalid command issued!";
     private static final String PADDING = " ";

--- a/src/main/java/wellnus/focus/command/NextCommand.java
+++ b/src/main/java/wellnus/focus/command/NextCommand.java
@@ -12,8 +12,8 @@ import wellnus.focus.feature.Session;
  * Represents a class to start the next countdown in the session.
  */
 public class NextCommand extends Command {
-    public static final String COMMAND_DESCRIPTION = "next - When a timer ends, move on to the next countdown!\n"
-            + "This can only be used when a countdown timer has ended!";
+    public static final String COMMAND_DESCRIPTION = "next - When a timer ends, move on to the next countdown!"
+            + System.lineSeparator() + "This can only be used when a countdown timer has ended!";
     public static final String COMMAND_USAGE = "usage: next";
     public static final String COMMAND_KEYWORD = "next";
     private static final int COMMAND_NUM_OF_ARGUMENTS = 1;

--- a/src/main/java/wellnus/focus/command/ResumeCommand.java
+++ b/src/main/java/wellnus/focus/command/ResumeCommand.java
@@ -12,8 +12,8 @@ import wellnus.focus.feature.Session;
  * Represents a command to resume the countdown timer in the current session.
  */
 public class ResumeCommand extends Command {
-    public static final String COMMAND_DESCRIPTION = "resume - Continue the countdown.\n"
-            + "Can only be used when a countdown is paused.";
+    public static final String COMMAND_DESCRIPTION = "resume - Continue the countdown."
+            + System.lineSeparator() + "Can only be used when a countdown is paused.";
     public static final String COMMAND_USAGE = "usage: home";
     public static final String COMMAND_KEYWORD = "resume";
     private static final int COMMAND_NUM_OF_ARGUMENTS = 1;

--- a/src/main/java/wellnus/focus/command/StopCommand.java
+++ b/src/main/java/wellnus/focus/command/StopCommand.java
@@ -102,7 +102,7 @@ public class StopCommand extends Command {
             throw new BadCommandException(COMMAND_INVALID_COMMAND_MESSAGE);
         }
         if (!arguments.get(COMMAND_KEYWORD).equals("")) {
-            throw new BadCommandException(COMMAND_INVALID_ARGUMENTS_MESSAGE);
+            throw new BadCommandException(COMMAND_INVALID_PAYLOAD);
         }
     }
 

--- a/src/main/java/wellnus/focus/feature/FocusManager.java
+++ b/src/main/java/wellnus/focus/feature/FocusManager.java
@@ -23,7 +23,7 @@ import wellnus.manager.Manager;
  */
 //@@author YongbinWang
 public class FocusManager extends Manager {
-    public static final String FEATURE_HELP_DESCRIPTION = "ft(Focus Timer) - Set a configurable 'Pomodoro' timer "
+    public static final String FEATURE_HELP_DESCRIPTION = "ft - Focus Timer - Set a configurable 'Pomodoro' timer "
             + "with work and rest cycles to keep yourself focused and productive!";
     public static final String FEATURE_NAME = "ft";
     private static final String START_COMMAND_KEYWORD = "start";

--- a/src/main/java/wellnus/focus/feature/FocusManager.java
+++ b/src/main/java/wellnus/focus/feature/FocusManager.java
@@ -69,6 +69,8 @@ public class FocusManager extends Manager {
             + "stop command " + StopCommand.COMMAND_USAGE + LINE_SEPARATOR
             + "help command " + HelpCommand.COMMAND_USAGE + LINE_SEPARATOR
             + "home command " + HomeCommand.COMMAND_USAGE;
+    private static final String HOME_USAGE = "home command " + HomeCommand.COMMAND_USAGE;
+    private static final String CONFIG_USAGE = "config command " + ConfigCommand.COMMAND_USAGE;
     private final FocusUi focusUi;
     private final Session session;
 
@@ -135,9 +137,23 @@ public class FocusManager extends Manager {
                 command.execute();
                 isExit = HomeCommand.isExit(command);
             } catch (BadCommandException exception) {
-                focusUi.printErrorFor(exception, COMMAND_INVALID_COMMAND_NOTE);
+                String errorMessage = exception.getMessage();
+                if (errorMessage.contains(CONFIG_COMMAND_KEYWORD)) {
+                    focusUi.printErrorFor(exception, CONFIG_USAGE);
+                } else if (errorMessage.contains(HOME_COMMAND_KEYWORD)) {
+                    focusUi.printErrorFor(exception, HOME_USAGE);
+                } else {
+                    focusUi.printErrorFor(exception, COMMAND_INVALID_COMMAND_NOTE);
+                }
             } catch (WellNusException exception) {
-                focusUi.printErrorFor(exception, COMMAND_INVALID_COMMAND_NOTE);
+                String errorMessage = exception.getMessage();
+                if (errorMessage.contains(CONFIG_COMMAND_KEYWORD)) {
+                    focusUi.printErrorFor(exception, CONFIG_USAGE);
+                } else if (errorMessage.contains(HOME_COMMAND_KEYWORD)) {
+                    focusUi.printErrorFor(exception, HOME_USAGE);
+                } else {
+                    focusUi.printErrorFor(exception, COMMAND_INVALID_COMMAND_NOTE);
+                }
             }
         }
     }

--- a/src/main/java/wellnus/gamification/GamificationManager.java
+++ b/src/main/java/wellnus/gamification/GamificationManager.java
@@ -32,6 +32,8 @@ public class GamificationManager extends Manager {
             + "stats command " + StatsCommand.COMMAND_USAGE + LINE_SEPARATOR
             + "help command " + HelpCommand.COMMAND_USAGE + LINE_SEPARATOR
             + "home command " + HomeCommand.COMMAND_USAGE;
+    private static final String STATS_USAGE = "stats command " + StatsCommand.COMMAND_USAGE;
+    private static final String HOME_USAGE = "home command " + HomeCommand.COMMAND_USAGE;
     private static final String LOAD_GAMIF_DATA_ERROR_MESSAGE = "Error saving to storage!";
     private GamificationData gamificationData;
     private final GamificationUi gamificationUi;
@@ -106,7 +108,14 @@ public class GamificationManager extends Manager {
                 command.execute();
                 isExit = HomeCommand.isHome(command);
             } catch (WellNusException exception) {
-                gamificationUi.printErrorFor(exception, COMMAND_INVALID_COMMAND_NOTE);
+                String errorMessage = exception.getMessage();
+                if (errorMessage.contains(COMMAND_STATS)) {
+                    gamificationUi.printErrorFor(exception, STATS_USAGE);
+                } else if (errorMessage.contains(COMMAND_HOME)) {
+                    gamificationUi.printErrorFor(exception, HOME_USAGE);
+                } else {
+                    gamificationUi.printErrorFor(exception, COMMAND_INVALID_COMMAND_NOTE);
+                }
             }
         }
     }

--- a/src/main/java/wellnus/gamification/GamificationManager.java
+++ b/src/main/java/wellnus/gamification/GamificationManager.java
@@ -20,7 +20,7 @@ import wellnus.manager.Manager;
  */
 public class GamificationManager extends Manager {
     public static final String FEATURE_NAME = "gamif";
-    public static final String FEATURE_HELP_DESCRIPTION = "gamif(Gamification) - Gamification gives you the "
+    public static final String FEATURE_HELP_DESCRIPTION = "gamif - Gamification - Gamification gives you the "
             + "motivation to continue improving your wellness by rewarding you for your efforts!";
     private static final String COMMAND_HELP = "help";
     private static final String COMMAND_HOME = "home";

--- a/src/main/java/wellnus/gamification/command/HelpCommand.java
+++ b/src/main/java/wellnus/gamification/command/HelpCommand.java
@@ -21,8 +21,9 @@ public class HelpCommand extends Command {
     private static final String COMMAND_INVALID_COMMAND_NOTE = "help command " + COMMAND_USAGE;
     private static final String COMMAND_KEYWORD = "help";
     private static final String NO_FEATURE_KEYWORD = "";
-    private static final String HELP_PREAMBLE = "Input `help` to see all available commands.\n"
-            + "Input `help [command-to-check]` to get usage help for a specific command.\n"
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final String HELP_PREAMBLE = "Input `help` to see all available commands." + LINE_SEPARATOR
+            + "Input `help [command-to-check]` to get usage help for a specific command." + LINE_SEPARATOR
             + "Here are all the commands available for you!";
     private static final String PADDING = " ";
     private static final String DOT = ".";

--- a/src/main/java/wellnus/gamification/command/StatsCommand.java
+++ b/src/main/java/wellnus/gamification/command/StatsCommand.java
@@ -17,8 +17,7 @@ public class StatsCommand extends Command {
     public static final String COMMAND_KEYWORD = "stats";
     public static final String COMMAND_USAGE = "usage: stats";
     public static final String FEATURE_NAME = "gamif";
-    private static final String EXTRA_ARGUMENTS_MESSAGE = "'%s' doesn't take in additional arguments, drop the '%s' "
-            + "and try again.";
+    private static final String INVALID_PAYLOAD = "Invalid payload given to 'stats'!";
     private static final int NUM_OF_ARGUMENTS = 1;
     private static final String WRONG_ARGUMENTS_MESSAGE = "Invalid arguments given to 'stats'!";
     private static final String WRONG_COMMAND_MESSAGE = "Invalid command issued, expected 'stats'!";
@@ -79,7 +78,7 @@ public class StatsCommand extends Command {
         }
         String payload = arguments.get(getCommandKeyword());
         if (!payload.isBlank()) {
-            throw new BadCommandException(String.format(EXTRA_ARGUMENTS_MESSAGE, getCommandKeyword(), payload));
+            throw new BadCommandException(INVALID_PAYLOAD);
         }
     }
 

--- a/src/main/java/wellnus/reflection/command/FavoriteCommand.java
+++ b/src/main/java/wellnus/reflection/command/FavoriteCommand.java
@@ -28,8 +28,6 @@ public class FavoriteCommand extends Command {
     private static final String COMMAND_KEYWORD_ASSERTION = "The key should be fav.";
     private static final String COMMAND_PAYLOAD_ASSERTION = "The payload should be empty.";
     private static final String INDEX_OUT_OF_BOUND_MSG = "Invalid index given, index is out of bound!";
-    private static final String INDEX_OUT_OF_BOUND_NOTES = "The index is out of range(e.g. negative integers, 0)!"
-            + System.lineSeparator() + "Your data file might be corrupted!";
     private static final String EMPTY_FAV_LIST = "There is nothing in favorite list, "
             + "please get reflection questions first!";
     private static final int ARGUMENT_PAYLOAD_SIZE = 1;

--- a/src/main/java/wellnus/reflection/command/FavoriteCommand.java
+++ b/src/main/java/wellnus/reflection/command/FavoriteCommand.java
@@ -116,7 +116,7 @@ public class FavoriteCommand extends Command {
             UI.printOutputMessage(outputString);
         } catch (IndexOutOfBoundsException indexOutOfBoundsException) {
             LOGGER.log(Level.WARNING, INDEX_OUT_OF_BOUND_MSG);
-            UI.printErrorFor(indexOutOfBoundsException, INDEX_OUT_OF_BOUND_NOTES);
+            UI.printErrorFor(indexOutOfBoundsException, INVALID_COMMAND_NOTES);
         }
     }
 

--- a/src/main/java/wellnus/reflection/command/HelpCommand.java
+++ b/src/main/java/wellnus/reflection/command/HelpCommand.java
@@ -23,8 +23,9 @@ public class HelpCommand extends Command {
     private static final String COMMAND_INVALID_COMMAND_NOTE = "help command " + COMMAND_USAGE;
     private static final String COMMAND_KEYWORD = "help";
     private static final String NO_FEATURE_KEYWORD = "";
-    private static final String HELP_PREAMBLE = "Input `help` to see all available commands.\n"
-            + "Input `help [command-to-check] to get usage help for a specific command.\n"
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final String HELP_PREAMBLE = "Input `help` to see all available commands." + LINE_SEPARATOR
+            + "Input `help [command-to-check] to get usage help for a specific command." + LINE_SEPARATOR
             + "Here are all the commands available for you!";
     private static final String PADDING = " ";
     private static final String DOT = ".";

--- a/src/main/java/wellnus/reflection/command/HelpCommand.java
+++ b/src/main/java/wellnus/reflection/command/HelpCommand.java
@@ -26,7 +26,6 @@ public class HelpCommand extends Command {
     private static final String HELP_PREAMBLE = "Input `help` to see all available commands.\n"
             + "Input `help [command-to-check] to get usage help for a specific command.\n"
             + "Here are all the commands available for you!";
-    private static final String ERROR_UNKNOWN_COMMAND = "Invalid command issued!";
     private static final String PADDING = " ";
     private static final String DOT = ".";
     private static final int ONE_OFFSET = 1;

--- a/src/main/java/wellnus/reflection/command/LikeCommand.java
+++ b/src/main/java/wellnus/reflection/command/LikeCommand.java
@@ -27,8 +27,8 @@ public class LikeCommand extends Command {
     private static final String INVALID_COMMAND_MSG = "Invalid command issued, expected 'like'!";
     private static final String INVALID_ARGUMENT_MSG = "Invalid arguments given to 'like'!";
     private static final String INVALID_COMMAND_NOTES = "like command " + COMMAND_USAGE;
-    private static final String WRONG_INDEX_MSG = "Invalid index payload given to 'like', index is out of range!";
-    private static final String WRONG_INDEX_NOTE = "Please input the correct index of the question you like!";
+    private static final String WRONG_INDEX_MSG = "Invalid index payload given to 'like', expected a valid integer!";
+    private static final String WRONG_INDEX_OUT_BOUND = "Invalid index payload given to 'like', index is out of range!";
     private static final String MISSING_SET_QUESTIONS = "A set of questions has not been gotten!";
     private static final String MISSING_SET_QUESTIONS_NOTES = "Please try 'get' command to generate a set of questions "
             + "before adding to favorite list!";
@@ -148,9 +148,10 @@ public class LikeCommand extends Command {
             UI.printErrorFor(storageException, STORAGE_ERROR);
         } catch (NumberFormatException numberFormatException) {
             LOGGER.log(Level.INFO, WRONG_INDEX_MSG);
-            UI.printErrorFor(numberFormatException, WRONG_INDEX_NOTE);
+            BadCommandException exception = new BadCommandException(WRONG_INDEX_MSG);
+            UI.printErrorFor(exception, INVALID_COMMAND_NOTES);
         } catch (ReflectionException reflectionException) {
-            UI.printErrorFor(reflectionException, WRONG_INDEX_NOTE);
+            UI.printErrorFor(reflectionException, INVALID_COMMAND_NOTES);
         }
     }
 
@@ -168,7 +169,7 @@ public class LikeCommand extends Command {
             NumberFormatException, ReflectionException {
         int questionIndexInt = Integer.parseInt(questionIndex);
         if (questionIndexInt > UPPER_BOUND || questionIndexInt < LOWER_BOUND) {
-            throw new ReflectionException(WRONG_INDEX_MSG);
+            throw new ReflectionException(WRONG_INDEX_OUT_BOUND);
         }
         if (!questionList.hasRandomQuestionIndexes()) {
             UI.printOutputMessage(MISSING_SET_QUESTIONS);

--- a/src/main/java/wellnus/reflection/command/LikeCommand.java
+++ b/src/main/java/wellnus/reflection/command/LikeCommand.java
@@ -29,8 +29,8 @@ public class LikeCommand extends Command {
     private static final String INVALID_COMMAND_NOTES = "like command " + COMMAND_USAGE;
     private static final String WRONG_INDEX_MSG = "Invalid index payload given to 'like', expected a valid integer!";
     private static final String WRONG_INDEX_OUT_BOUND = "Invalid index payload given to 'like', index is out of range!";
-    private static final String MISSING_SET_QUESTIONS = "A set of questions has not been gotten!";
-    private static final String MISSING_SET_QUESTIONS_NOTES = "Please try 'get' command to generate a set of questions "
+    private static final String MISSING_SET_QUESTIONS = "A set of questions has not been gotten!"
+            + System.lineSeparator() + "Please try 'get' command to generate a set of questions "
             + "before adding to favorite list!";
     private static final String TOKENIZER_ERROR = "Error tokenizing data!";
     private static final String STORAGE_ERROR = "Error saving to storage!";
@@ -139,7 +139,7 @@ public class LikeCommand extends Command {
             addFavQuestion(getArguments().get(COMMAND_KEYWORD));
         } catch (BadCommandException badCommandException) {
             LOGGER.log(Level.INFO, MISSING_SET_QUESTIONS);
-            UI.printErrorFor(badCommandException, MISSING_SET_QUESTIONS_NOTES);
+            UI.printErrorFor(badCommandException, INVALID_COMMAND_NOTES);
         } catch (TokenizerException tokenizerException) {
             LOGGER.log(Level.WARNING, TOKENIZER_ERROR);
             UI.printErrorFor(tokenizerException, TOKENIZER_ERROR);

--- a/src/main/java/wellnus/reflection/command/PrevCommand.java
+++ b/src/main/java/wellnus/reflection/command/PrevCommand.java
@@ -24,10 +24,11 @@ public class PrevCommand extends Command {
     private static final String INVALID_COMMAND_NOTES = "prev command " + COMMAND_USAGE;
     private static final String COMMAND_KEYWORD_ASSERTION = "The key should be prev.";
     private static final String COMMAND_PAYLOAD_ASSERTION = "The payload should be empty.";
-    private static final String MISSING_SET_QUESTIONS = "A set of questions has not been gotten.";
-    private static final String INDEX_OUT_OF_BOUND_MSG = "Invalid index payload given, index is out of bound!";
-    private static final String INDEX_OUT_OF_BOUND_NOTES = "The index is out of range (e.g. negative integers, 0)!"
-            + System.lineSeparator() + "Your data file might be corrupted!";
+    private static final String MISSING_SET_QUESTIONS = "A set of questions has not been gotten!"
+            + System.lineSeparator() + "Please try 'get' command to generate a set of questions "
+            + "before reviewing them!";
+    private static final String INDEX_OUT_OF_BOUND_MSG = "Invalid index payload given to 'prev', "
+            + "index is out of bound!";
     private static final String PAYLOAD = "";
     private static final int ARGUMENT_PAYLOAD_SIZE = 1;
     private static final Logger LOGGER = WellNusLogger.getLogger("ReflectPrevCommandLogger");

--- a/src/main/java/wellnus/reflection/command/PrevCommand.java
+++ b/src/main/java/wellnus/reflection/command/PrevCommand.java
@@ -134,7 +134,7 @@ public class PrevCommand extends Command {
             getPrevSetQuestions();
         } catch (IndexOutOfBoundsException indexOutOfBoundsException) {
             LOGGER.log(Level.WARNING, INDEX_OUT_OF_BOUND_MSG);
-            UI.printErrorFor(indexOutOfBoundsException, INDEX_OUT_OF_BOUND_NOTES);
+            UI.printErrorFor(indexOutOfBoundsException, INVALID_COMMAND_NOTES);
         } catch (BadCommandException badCommandException) {
             LOGGER.log(Level.WARNING, MISSING_SET_QUESTIONS);
             UI.printErrorFor(badCommandException, INVALID_COMMAND_NOTES);

--- a/src/main/java/wellnus/reflection/command/UnlikeCommand.java
+++ b/src/main/java/wellnus/reflection/command/UnlikeCommand.java
@@ -28,9 +28,9 @@ public class UnlikeCommand extends Command {
     private static final String INVALID_COMMAND_MSG = "Invalid command issued, expected 'unlike'!";
     private static final String INVALID_ARGUMENT_MSG = "Invalid arguments given to 'unlike'!";
     private static final String INVALID_COMMAND_NOTES = "unlike command " + COMMAND_USAGE;
-    private static final String WRONG_INDEX_MSG = "Invalid index payload given to 'unlike', index is out of range!";
-    private static final String WRONG_INDEX_NOTE = "Please input the correct index of the question you like!";
-    private static final String COMMAND_KEYWORD_ASSERTION = "The key should be unlike.";
+    private static final String WRONG_INDEX_MSG = "Invalid index payload given to 'unlike', expected a valid integer!";
+    private static final String WRONG_INDEX_OUT_BOUND = "Invalid index payload given to 'unlike', "
+            + "index is out of range!";
     private static final String EMPTY_FAV_LIST_MSG = "The favorite list is empty, there is nothing to be removed.";
     private static final String TOKENIZER_ERROR = "Error tokenizing data!";
     private static final String STORAGE_ERROR = "Error saving to storage!";
@@ -146,9 +146,10 @@ public class UnlikeCommand extends Command {
             UI.printErrorFor(storageException, STORAGE_ERROR);
         } catch (NumberFormatException numberFormatException) {
             LOGGER.log(Level.INFO, WRONG_INDEX_MSG);
-            UI.printErrorFor(numberFormatException, WRONG_INDEX_NOTE);
+            BadCommandException exception = new BadCommandException(WRONG_INDEX_MSG);
+            UI.printErrorFor(exception, INVALID_COMMAND_NOTES);
         } catch (ReflectionException reflectionException) {
-            UI.printErrorFor(reflectionException, WRONG_INDEX_NOTE);
+            UI.printErrorFor(reflectionException, INVALID_COMMAND_NOTES);
         } catch (BadCommandException badCommandException) {
             LOGGER.log(Level.INFO, INVALID_COMMAND_MSG);
             UI.printErrorFor(badCommandException, INVALID_COMMAND_NOTES);
@@ -175,7 +176,7 @@ public class UnlikeCommand extends Command {
             return;
         }
         if (questionIndexInt > this.favQuestionIndexes.size() || questionIndexInt < LOWER_BOUND) {
-            throw new ReflectionException(WRONG_INDEX_MSG);
+            throw new ReflectionException(WRONG_INDEX_OUT_BOUND);
         }
         IndexMapper indexMapper = new IndexMapper(this.favQuestionIndexes);
         HashMap<Integer, Integer> indexQuestionMap = indexMapper.mapIndex();

--- a/src/main/java/wellnus/reflection/feature/QuestionList.java
+++ b/src/main/java/wellnus/reflection/feature/QuestionList.java
@@ -46,15 +46,16 @@ public class QuestionList {
     private static final int INCREMENT_ONE = 1;
     private static final String TOTAL_NUM_QUESTION_ASSERTIONS = "The total number of questions is 10.";
     private static final String ADD_FAV_SUCCESS_ONE = "You have added question: ";
-    private static final String ADD_FAV_SUCCESS_TWO = " into favorite list!!";
+    private static final String ADD_FAV_SUCCESS_TWO = " Into favorite list!!";
     private static final String REMOVE_FAV_SUCCESS_ONE = "You have removed question: ";
-    private static final String REMOVE_FAV_SUCCESS_TWO = " from favorite list!!";
-    private static final String DUPLICATE_LIKE = " is already in the favorite list!";
+    private static final String REMOVE_FAV_SUCCESS_TWO = " From favorite list!!";
+    private static final String DUPLICATE_LIKE = " Is already in the favorite list!";
     private static final String TOKENIZER_ERROR = "Error tokenizing data!";
     private static final String STORAGE_ERROR = "Error saving to storage!";
     private static final String DOT = ".";
     private static final String EMPTY_STRING = "";
     private static final String FILE_NAME = "reflect";
+    private static final String QUOTE = "\"";
     private static final RandomNumberGenerator RANDOM_NUMBER_GENERATOR =
             new RandomNumberGenerator(RANDOM_NUMBER_UPPERBOUND);
     private static final Logger LOGGER = WellNusLogger.getLogger("ReflectQuestionListLogger");
@@ -192,12 +193,13 @@ public class QuestionList {
      */
     public void addFavListIndex(int indexToAdd) throws StorageException {
         if (this.dataIndex.get(INDEX_ZERO).contains(indexToAdd)) {
-            UI.printOutputMessage(questions.get(indexToAdd).toString() + DUPLICATE_LIKE);
+            UI.printOutputMessage(QUOTE + questions.get(indexToAdd).toString() + QUOTE + DUPLICATE_LIKE);
             return;
         }
         this.dataIndex.get(INDEX_ZERO).add(indexToAdd);
         this.storeQuestionData();
-        UI.printOutputMessage(ADD_FAV_SUCCESS_ONE + this.questions.get(indexToAdd).toString() + ADD_FAV_SUCCESS_TWO);
+        UI.printOutputMessage(ADD_FAV_SUCCESS_ONE + QUOTE + this.questions.get(indexToAdd).toString() + QUOTE
+                + ADD_FAV_SUCCESS_TWO);
     }
 
     /**
@@ -211,7 +213,7 @@ public class QuestionList {
     public void removeFavListIndex(int indexToRemove) throws StorageException {
         this.dataIndex.get(INDEX_ZERO).remove(indexToRemove);
         this.storeQuestionData();
-        UI.printOutputMessage(REMOVE_FAV_SUCCESS_ONE + this.questions.get(indexToRemove).toString()
+        UI.printOutputMessage(REMOVE_FAV_SUCCESS_ONE + QUOTE + this.questions.get(indexToRemove).toString() + QUOTE
                 + REMOVE_FAV_SUCCESS_TWO);
     }
 

--- a/src/main/java/wellnus/reflection/feature/ReflectionManager.java
+++ b/src/main/java/wellnus/reflection/feature/ReflectionManager.java
@@ -21,7 +21,7 @@ import wellnus.reflection.command.UnlikeCommand;
  * This class oversees the command execution for self reflection section.
  */
 public class ReflectionManager extends Manager {
-    public static final String FEATURE_HELP_DESCRIPTION = "reflect(Self Reflection) - Take some time to pause "
+    public static final String FEATURE_HELP_DESCRIPTION = "reflect - Self Reflection - Take some time to pause "
             + "and reflect with our specially curated list of questions and reflection management tools.";
     public static final String FEATURE_NAME = "reflect";
     private static final Logger LOGGER = WellNusLogger.getLogger("ReflectionManagerLogger");

--- a/src/test/java/wellnus/focus/command/ConfigCommandTest.java
+++ b/src/test/java/wellnus/focus/command/ConfigCommandTest.java
@@ -29,7 +29,7 @@ public class ConfigCommandTest {
             + System.lineSeparator()
             + "Error Message:"
             + System.lineSeparator()
-            + "Invalid minutes payload given, the maximum time you can set is 60"
+            + "Invalid minutes payload given in 'config', the maximum time you can set is 60!"
             + System.lineSeparator()
             + "Note:"
             + System.lineSeparator()
@@ -43,7 +43,7 @@ public class ConfigCommandTest {
             + System.lineSeparator()
             + "Error Message:"
             + System.lineSeparator()
-            + "Invalid minutes payload given, the minimum time you can set is 1"
+            + "Invalid minutes payload given in 'config', the minimum time you can set is 1!"
             + System.lineSeparator()
             + "Note:"
             + System.lineSeparator()
@@ -56,7 +56,7 @@ public class ConfigCommandTest {
             + System.lineSeparator()
             + "Error Message:"
             + System.lineSeparator()
-            + "Invalid cycle payload given, the maximum cycles you can set is 5"
+            + "Invalid cycle payload given in 'config', the maximum cycles you can set is 5!"
             + System.lineSeparator()
             + "Note:"
             + System.lineSeparator()
@@ -70,7 +70,7 @@ public class ConfigCommandTest {
             + System.lineSeparator()
             + "Error Message:"
             + System.lineSeparator()
-            + "Invalid cycle payload given, the minimum cycles you can set is 2"
+            + "Invalid cycle payload given in 'config', the minimum cycles you can set is 2!"
             + System.lineSeparator()
             + "Note:"
             + System.lineSeparator()
@@ -84,7 +84,7 @@ public class ConfigCommandTest {
             + System.lineSeparator()
             + "Error Message:"
             + System.lineSeparator()
-            + "Invalid integer payload given!"
+            + "Invalid payload given in 'config', expected a valid integer!"
             + System.lineSeparator()
             + "Note:"
             + System.lineSeparator()


### PR DESCRIPTION
This pr
- fixes #304 format of `help` features
- fixes #309 Standardise error message for gamif `stats`
- fixes #311 Inconsistent error message for reflect
- fixes #314 Question string
- fixes #316 on reflect and gamif error notes
- fixes #323 Inconsistent indentation for help and update user guide for help command