### PR TITLE
Remove extra space printed for MainManger when invalid command is given

### DIFF
--- a/src/main/java/wellnus/common/MainManager.java
+++ b/src/main/java/wellnus/common/MainManager.java
@@ -43,7 +43,7 @@ public class MainManager extends Manager {
     private static final String INVALID_COMMAND_ADDITIONAL_MESSAGE =
             "Supported features: " + LINE_SEPARATOR
             + "Access Atomic Habit: hb" + LINE_SEPARATOR
-            + "Access Self Reflection : reflect" + LINE_SEPARATOR
+            + "Access Self Reflection: reflect" + LINE_SEPARATOR
             + "Access Focus Timer: ft" + LINE_SEPARATOR
             + "Access Gamification: gamif" + LINE_SEPARATOR
             + "Help command: help" + LINE_SEPARATOR

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -16,7 +16,7 @@ Error Message:
 Note:
     Supported features:
     Access Atomic Habit: hb
-    Access Self Reflection : reflect
+    Access Self Reflection: reflect
     Access Focus Timer: ft
     Access Gamification: gamif
     Help command: help


### PR DESCRIPTION
Extra space for error message printing.